### PR TITLE
Chore/pyopensci eic checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,14 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # 3.15 is still a pre-release; it is tested for forward compatibility
+    # but allowed to fail so a Python alpha or a not-yet-built dependency
+    # wheel does not turn the whole pipeline red.
+    continue-on-error: ${{ matrix.python-version == '3.15' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +27,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # 3.15 is still a pre-release; it is tested for forward compatibility
-    # but allowed to fail so a Python alpha or a not-yet-built dependency
-    # wheel does not turn the whole pipeline red.
-    continue-on-error: ${{ matrix.python-version == '3.15' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
@@ -27,7 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
 
       - name: Install
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Plan is listed under the published version it shipped in.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-05
+
+First minor release. The version bump from the `0.0.x` line signals that
+the public API in `purgedcv/__init__.py` is now considered usable and is
+maintained deliberately: the splitters, backtest-path reconstruction, and
+the Sharpe-ratio metric family are stable enough to build on. Breaking
+changes will still happen before `1.0.0`, but they will be noted here
+rather than slipped into a patch release.
+
 ### Added
 
 - `probability_of_backtest_overfitting` (PBO): estimates how often the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     family-names: Lazarev
     email: elazarev@gmail.com
     orcid: "https://orcid.org/0009-0000-1398-7842"
-version: 0.0.10
-date-released: "2026-05-23"
+version: 0.1.0
+date-released: "2026-06-05"
 repository-code: "https://github.com/eslazarev/purged-cross-validation"
 url: "https://github.com/eslazarev/purged-cross-validation"
 license: MIT

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ references will fail the build.
 
 ## What needs an end-to-end test
 
-Any user-visible behaviour — a new splitter, a metric, a diagnostic, or a
-new CLI tool under `tools/` — needs an entry in `tests/e2e/`. Unit and
+Any user-visible behaviour (a new splitter, a metric, a diagnostic, or a
+new CLI tool under `tools/`) needs an entry in `tests/e2e/`. Unit and
 property tests stay in `tests/` (flat). When a feature spans multiple
 modules, prefer a subprocess-style e2e test that exercises the public API
 the way a user would.
@@ -62,23 +62,28 @@ python tools/prose_gate.py
 ```
 
 Any **FAIL** result blocks a PR; **WARN** is advisory. The gate is a
-heuristic and not a detector — but it catches regressions reliably. If you
+heuristic and not a detector, but it catches regressions reliably. If you
 disagree with a flag in your prose, raise it in the PR.
 
 ## Commit messages and pull requests
 
 - Conventional commits style is appreciated (`feat:`, `fix:`, `chore:`,
   `docs:`, `test:`). Not enforced.
-- Keep PRs focused. One feature, one fix, one refactor — not a mix.
+- Keep PRs focused. One feature, one fix, one refactor, not a mix.
 - Update `CHANGELOG.md` under `Unreleased` if your change is user-visible.
-- The release workflow bumps the patch version on every push to `main`
-  (alpha-aware), so do not bump it yourself.
+- The release workflow publishes to PyPI and bumps the patch version only
+  when a push to `main` changes the shipped package (`src/**` or
+  `pyproject.toml`). Merges that touch only docs, tests, CI, tooling, or
+  examples do not release. For an ordinary change do not bump the version
+  yourself; the workflow bumps the patch (alpha-aware) after publishing.
+  To jump a minor or major version on purpose, set it deliberately in both
+  `pyproject.toml` and `src/purgedcv/__init__.py` in your PR.
 
 ## Reporting bugs and requesting features
 
 Open an issue from one of the templates in `.github/ISSUE_TEMPLATE/`. For
 bug reports, the most helpful thing you can include is a minimal
-reproducer — a few lines of code, the actual output, and the expected
+reproducer: a few lines of code, the actual output, and the expected
 output. For feature requests, describing the cross-validation use case
 matters more than describing the API you would like.
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,25 @@ print(f"MinTRL: {int(n_min)} observations")
 
 ---
 
+## Contributing and development
+
+Bug reports, feature requests, and pull requests are welcome. The full
+development setup, the local gates (`ruff`, `black`, `mypy --strict`,
+`pytest`, `mkdocs build --strict`), the end-to-end test convention, and the
+prose-quality gate are documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+Conduct is governed by the [Contributor Covenant](CODE_OF_CONDUCT.md);
+security reports go through [SECURITY.md](SECURITY.md).
+
+## Use of generative AI
+
+This project was developed with the help of AI coding assistants.
+They were used to draft and refactor implementation code, expand the test
+suite, and edit documentation. The methodology, the public API design, the
+choice and execution of every experiment, and all reported numbers are the
+author's own: each empirical result in this repository comes from a script
+in `examples/` or `tools/` that is committed and reproducible, and the
+numbers were verified against those runs rather than generated as text.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security policy
+
+`purgedcv` is a pure-Python library for cross-validation and backtest
+statistics. It does not run a server, open network connections, execute
+untrusted input, or handle credentials, so its attack surface is small.
+The most likely security-relevant issue is a dependency advisory or a bug
+that lets crafted input cause unexpected resource use.
+
+## Supported versions
+
+Fixes are released against the latest published version on PyPI. The
+project is pre-1.0, so there is no long-term support branch: please
+upgrade to the newest release before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| latest release on PyPI | yes |
+| older releases | no |
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately rather than opening a
+public issue. Two ways:
+
+- Use GitHub's **Report a vulnerability** button under the repository's
+  **Security** tab (private advisory).
+- Or email **elazarev@gmail.com** with a description and, if possible, a
+  minimal reproducer.
+
+You can expect an acknowledgement within about a week. If the report is
+confirmed, a fix and a new release follow, and you will be credited in the
+release notes unless you ask otherwise. If a report is declined, you will
+get an explanation of why.
+
+## Dependencies
+
+Runtime dependencies are pinned to lower bounds in `pyproject.toml` and
+kept current. If you find that `purgedcv` pulls in a dependency version
+with a known advisory, that is in scope: please report it the same way.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "purgedcv"
-version = "0.0.13"
+version = "0.1.0"
 description = "scikit-learn-compatible cross-validation for time-series and financial machine learning: purging, embargoes, combinatorial purged CV, and deflated Sharpe ratios."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/purgedcv/__init__.py
+++ b/src/purgedcv/__init__.py
@@ -25,7 +25,7 @@ from purgedcv.exceptions import (
     TemporalLeakageError,
 )
 
-__version__ = "0.0.13"
+__version__ = "0.1.0"
 
 __all__ = [
     "BaseTemporalSplitter",


### PR DESCRIPTION
## What changes

A short description of the change and the reason for it. Link any issues
it fixes (`Fixes #123`).

## Checklist

- [ ] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [ ] `mypy src tests` is clean.
- [ ] `pytest -q` is green locally.
- [ ] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
- [ ] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
- [ ] If the docs site is affected, `mkdocs build --strict` is clean.
- [ ] `CHANGELOG.md` has an entry under `Unreleased`, if the change is
      user-visible.

## Notes for the reviewer

Anything the diff alone does not make obvious: a behaviour change to
flag, a textbook reference for the algorithm, a known limitation, or a
follow-up issue.
