### PR TITLE
docs: update documentation for sample weights and clarify max_drawdow…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ Plan is listed under the published version it shipped in.
   Implements Bailey, Borwein, Lopez de Prado & Zhu (2014), "Pseudo-mathematics
   and financial charlatanism".
 
+### Documentation
+
+- Quickstart now shows how to pass `sample_weight` through the splitters.
+  Because the splitters stay drop-in to scikit-learn and ship no scorer of
+  their own, weights travel via sklearn metadata routing
+  (`enable_metadata_routing`, `set_fit_request`/`set_score_request`); the
+  section covers both train-time-only weighting and weighting the score
+  through a custom scorer, and the `UnsetMetadataPassedError` it raises if
+  the scorer neither requests nor declines the weight.
+- `path_metrics` docstring states the `max_drawdown` sign convention at the
+  point of use (positive magnitude; worst path is `idxmax`, not `idxmin`),
+  matching the note already in `default_backtest_metrics`.
+
 ## [0.1.0] - 2026-06-05
 
 First minor release. The version bump from the `0.0.x` line signals that

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Why write another one? People have asked scikit-learn, auto-sklearn, and mlpack 
 
 ## Does it actually catch leakage?
 
-A controlled check on synthetic data whose target is built so that **no feature can predict it**. The honest out-of-sample score must never be positive. Naive shuffled k-fold runs against `PurgedKFold` side by side ([examples/synthetic_leakage_proof.ipynb](examples/synthetic_leakage_proof.ipynb), deterministic, no download; run it in your browser on [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/code/evgeniilazarev/when-cross-validation-lies-a-controlled-study-on)):
+A controlled check on synthetic data whose target is built so that **no feature can predict it**. The honest out-of-sample score must never be positive. Naive shuffled k-fold runs against `PurgedKFold` side by side ([examples/synthetic_leakage_proof.ipynb](examples/synthetic_leakage_proof.ipynb), deterministic, no downloads):
 
 | model | naive shuffled KFold R² | PurgedKFold R² |
 |---|--:|--:|

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,6 +75,57 @@ print("honest R^2 per fold:", scores)
 (chronological train-on-the-past, expanding or rolling) follow the same
 constructor pattern.
 
+### Sample weights
+
+The splitters carry no scorer of their own; they stay drop-in to
+scikit-learn, so sample weights travel through sklearn's own metadata
+routing rather than through any `purgedcv` argument. Enable routing once,
+then have the estimator request the weight for `fit`. The split itself is
+unaffected: weights ride along with the rows each fold keeps.
+
+```python
+import numpy as np
+import pandas as pd
+import sklearn
+from sklearn.linear_model import Ridge
+from sklearn.metrics import make_scorer, mean_squared_error
+from sklearn.model_selection import cross_val_score
+from purgedcv import PurgedKFold
+
+n, h = 300, 5
+rng = np.random.default_rng(0)
+features = rng.standard_normal((n, 3))
+labels = rng.standard_normal(n)
+weights = rng.uniform(0.5, 1.5, n)
+pred = pd.Series(pd.date_range("2024-01-01", periods=n, freq="D"))
+evalu = pred + pd.Timedelta(days=h)
+cv = PurgedKFold(n_splits=5, prediction_times=pred, evaluation_times=evalu,
+                 purge_horizon=f"{h}D")
+
+sklearn.set_config(enable_metadata_routing=True)
+
+# Train-time weighting only. The estimator requests the weight for fit and
+# explicitly declines it for score, so cross_val_score knows where it goes.
+est = Ridge().set_fit_request(sample_weight=True).set_score_request(sample_weight=False)
+scores = cross_val_score(est, features, labels, cv=cv, params={"sample_weight": weights})
+
+# Weight the score as well: route the weight into fit and into a scorer that
+# also requests it. Without this, the default scorer leaves the test fold
+# unweighted.
+est = Ridge().set_fit_request(sample_weight=True)
+scorer = make_scorer(mean_squared_error, greater_is_better=False).set_score_request(
+    sample_weight=True
+)
+scores_w = cross_val_score(est, features, labels, cv=cv, scoring=scorer,
+                           params={"sample_weight": weights})
+```
+
+The gotcha is the second case: if you route `sample_weight` but leave the
+default scorer, sklearn raises `UnsetMetadataPassedError` because the scorer
+neither requested nor declined the weight. Decline it with
+`set_score_request(sample_weight=False)` for train-only weighting, or pass a
+scorer that requests it for weighted evaluation.
+
 ## 3. CPCV + backtest paths + deflated Sharpe
 
 The full workflow from chapter 12 of *Advances in Financial Machine

--- a/src/purgedcv/_path_metrics.py
+++ b/src/purgedcv/_path_metrics.py
@@ -128,7 +128,10 @@ def path_metrics(
 
     Returns:
         DataFrame indexed ``0 .. n_paths - 1`` (index name ``"path"``) with
-        one column per metric.
+        one column per metric. With the default ``metric_fn`` the
+        ``max_drawdown`` column is a **positive magnitude** (``0.30`` = a 30%
+        drawdown), so the worst path is ``df["max_drawdown"].idxmax()``, not
+        ``idxmin()``; see :func:`default_backtest_metrics`.
 
     Raises:
         ValueError: if ``paths`` is not 2-D.


### PR DESCRIPTION
…n sign convention

## What changes

A short description of the change and the reason for it. Link any issues
it fixes (`Fixes #123`).

## Checklist

- [ ] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [ ] `mypy src tests` is clean.
- [ ] `pytest -q` is green locally.
- [ ] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
- [ ] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
- [ ] If the docs site is affected, `mkdocs build --strict` is clean.
- [ ] `CHANGELOG.md` has an entry under `Unreleased`, if the change is
      user-visible.

## Notes for the reviewer

Anything the diff alone does not make obvious: a behaviour change to
flag, a textbook reference for the algorithm, a known limitation, or a
follow-up issue.
