### PR TITLE
Docs/anaconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/eslazarev/purged-cross-validation/actions/workflows/ci.yml/badge.svg)](https://github.com/eslazarev/purged-cross-validation/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/eslazarev/purged-cross-validation/branch/main/graph/badge.svg)](https://codecov.io/gh/eslazarev/purged-cross-validation)
 [![PyPI version](https://img.shields.io/pypi/v/purgedcv)](https://pypi.org/project/purgedcv/)
+[![Conda version](https://img.shields.io/conda/vn/conda-forge/purgedcv)](https://anaconda.org/conda-forge/purgedcv)
 [![PyPI downloads](https://static.pepy.tech/badge/purgedcv)](https://pepy.tech/project/purgedcv)
 [![PyPI wheel](https://img.shields.io/pypi/wheel/purgedcv)](https://pypi.org/project/purgedcv/#files)
 
@@ -137,6 +138,10 @@ Both strategies lose money over the sideways-down deployment window; the naive p
 ```bash
 
 pip install purgedcv
+
+# Or from conda-forge (conda or mamba)
+conda install -c conda-forge purgedcv
+mamba install -c conda-forge purgedcv
 
 # Directly from the repository
 pip install git+https://github.com/eslazarev/purged-cross-validation.git

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ the original papers and pinned by 354 tests (98% line coverage).
 
 ## Where to start
 
-- [Installation](installation.md) — `pip install purgedcv`, optional extras.
+- [Installation](installation.md) — `pip install purgedcv` or `conda install -c conda-forge purgedcv`, optional extras.
 - [Quickstart](quickstart.md) — three short runnable snippets.
 - [API reference](api.md) — autodoc for every public symbol.
 - [Examples](examples.md) — eleven worked notebooks on real public data.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-`purgedcv` is on PyPI and requires Python 3.10 or newer.
+`purgedcv` is on PyPI and conda-forge, and requires Python 3.10 or newer.
 
 ## From PyPI
 
@@ -8,6 +8,16 @@ The base install gets the splitters, metrics, and diagnostics:
 
 ```bash
 pip install purgedcv
+```
+
+## From conda-forge
+
+For conda or mamba users, the package is published on conda-forge:
+
+```bash
+conda install -c conda-forge purgedcv
+# or
+mamba install -c conda-forge purgedcv
 ```
 
 ## Optional extras


### PR DESCRIPTION
## What changes

A short description of the change and the reason for it. Link any issues
it fixes (`Fixes #123`).

## Checklist

- [ ] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [ ] `mypy src tests` is clean.
- [ ] `pytest -q` is green locally.
- [ ] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
- [ ] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
- [ ] If the docs site is affected, `mkdocs build --strict` is clean.
- [ ] `CHANGELOG.md` has an entry under `Unreleased`, if the change is
      user-visible.

## Notes for the reviewer

Anything the diff alone does not make obvious: a behaviour change to
flag, a textbook reference for the algorithm, a known limitation, or a
follow-up issue.
