### PR TITLE
feat: implement framework-agnostic time inputs for numpy and polars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Plan is listed under the published version it shipped in.
 
 ## [Unreleased]
 
+### Added
+
+- Time inputs are now framework-agnostic. `prediction_times`,
+  `evaluation_times`, and `groups` on every splitter, together with `purge`,
+  `apply_embargo`, `validate_times`, and the `diagnostics` functions, accept
+  pandas `Series`/`DatetimeIndex`, NumPy `datetime64`/`timedelta64` arrays,
+  Python lists of datetime/Timestamp/timedelta values, and polars `Series`.
+  Inputs are coerced to NumPy once at the public boundary; polars is
+  duck-typed through `.to_numpy()` and never imported, so it stays out of the
+  runtime dependencies. tz-aware pandas input is normalized to UTC. The
+  pandas input path is unchanged; the public signatures widen to a new
+  `TimesLike` type alias.
+
 ## [0.1.2] - 2026-06-13
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,17 @@ Plan is listed under the published version it shipped in.
 
 ### Added
 
-- Time inputs are now framework-agnostic. `prediction_times`,
-  `evaluation_times`, and `groups` on every splitter, together with `purge`,
-  `apply_embargo`, `validate_times`, and the `diagnostics` functions, accept
-  pandas `Series`/`DatetimeIndex`, NumPy `datetime64`/`timedelta64` arrays,
-  Python lists of datetime/Timestamp/timedelta values, and polars `Series`.
-  Inputs are coerced to NumPy once at the public boundary; polars is
+- Time inputs are now framework-agnostic. `prediction_times` and
+  `evaluation_times` on every splitter, together with `purge`, `apply_embargo`,
+  `validate_times`, and the `diagnostics` functions, accept pandas
+  `Series`/`DatetimeIndex`, NumPy `datetime64`/`timedelta64` arrays, Python
+  lists of datetime/Timestamp/timedelta values, and polars `Series`. Inputs are
+  coerced to a 1-D NumPy array once at the public boundary; polars is
   duck-typed through `.to_numpy()` and never imported, so it stays out of the
-  runtime dependencies. tz-aware pandas input is normalized to UTC. The
-  pandas input path is unchanged; the public signatures widen to a new
-  `TimesLike` type alias.
+  runtime dependencies. tz-aware pandas input is normalized to UTC. `groups`
+  accepts the same containers but holds arbitrary 1-D labels, not timestamps.
+  The pandas input path is unchanged; the widened public signatures use the new
+  exported `TimesLike` (times) and `ArrayLike1D` (labels) type aliases.
 
 ## [0.1.2] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![CodeFactor](https://www.codefactor.io/repository/github/eslazarev/purged-cross-validation/badge)](https://www.codefactor.io/repository/github/eslazarev/purged-cross-validation)
+[![Mentioned in Awesome Quant](https://awesome.re/mentioned-badge.svg)](https://github.com/wilsonfreitas/awesome-quant)
 
 **[Documentation →](https://eslazarev.github.io/purged-cross-validation/)** · **[Example notebooks →](https://github.com/eslazarev/purged-cross-validation/tree/main/examples)** · purge/embargo, walk-forward, and CPCV with PSR/DSR worked end to end on real ICU-mortality, turbofan-RUL, rainfall, and electricity-demand data.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,12 @@ keyword arguments (`prediction_times`, `evaluation_times`,
 [`BaseTemporalSplitter`](#purgedcv.BaseTemporalSplitter) for the shared
 contract.
 
+## Input type aliases
+
+::: purgedcv.TimesLike
+
+::: purgedcv.ArrayLike1D
+
 ## Splitters
 
 ::: purgedcv.BaseTemporalSplitter

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,11 +81,18 @@ python -c "import purgedcv; print(purgedcv.__version__)"
 should print the installed version. The full public surface is in
 [`purgedcv.__all__`](api.md).
 
-## Time inputs
+## Time and group inputs
 
-`prediction_times`, `evaluation_times`, and `groups` accept pandas `Series` or
+`prediction_times` and `evaluation_times` accept pandas `Series` or
 `DatetimeIndex`, numpy `datetime64` or `timedelta64` arrays, Python lists of
-datetime/Timestamp/timedelta values, and polars `Series`. Inputs are converted
-to numpy once at the boundary, and polars is never imported, so it is not a
-runtime dependency, only an optional convenience for callers who already have
-a polars `Series` on hand. tz-aware pandas input is normalized to UTC.
+datetime/Timestamp/timedelta values, and polars `Series`. They are coerced to a
+1-D numpy array once at the boundary and must hold a datetime64 or timedelta64
+dtype; tz-aware pandas input is normalized to UTC.
+
+`groups` accepts the same container types but holds arbitrary 1-D labels
+(integers, strings, categories), not timestamps.
+
+polars is never imported, so it is not a runtime dependency, only an optional
+convenience for callers who already hold a polars `Series`. The accepted-input
+type aliases `TimesLike` (for times) and `ArrayLike1D` (for labels) are exported
+from `purgedcv` for annotating your own code.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,3 +80,12 @@ python -c "import purgedcv; print(purgedcv.__version__)"
 
 should print the installed version. The full public surface is in
 [`purgedcv.__all__`](api.md).
+
+## Time inputs
+
+`prediction_times`, `evaluation_times`, and `groups` accept pandas `Series` or
+`DatetimeIndex`, numpy `datetime64` or `timedelta64` arrays, Python lists of
+datetime/Timestamp/timedelta values, and polars `Series`. Inputs are converted
+to numpy once at the boundary, and polars is never imported, so it is not a
+runtime dependency, only an optional convenience for callers who already have
+a polars `Series` on hand. tz-aware pandas input is normalized to UTC.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ line-length = 100
 target-version = ["py310", "py311", "py312", "py313", "py314"]
 
 [tool.mypy]
-python_version = "3.10"
 strict = true
 warn_return_any = true
 warn_unused_configs = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
     "hypothesis>=6.80",
+    "polars>=0.20",
     "black>=24.0",
     "ruff>=0.5",
     "mypy>=1.10",

--- a/src/purgedcv/__init__.py
+++ b/src/purgedcv/__init__.py
@@ -18,6 +18,7 @@ from purgedcv._pbo import probability_of_backtest_overfitting
 from purgedcv._purge import purge
 from purgedcv._purged_kfold import PurgedGroupKFold, PurgedKFold
 from purgedcv._time import horizons_overlap, parse_horizon, validate_times
+from purgedcv._typing import ArrayLike1D, TimesLike
 from purgedcv._walk_forward import WalkForwardSplit
 from purgedcv.exceptions import (
     EmbargoViolationError,
@@ -29,6 +30,7 @@ from purgedcv.exceptions import (
 __version__ = "0.1.2"
 
 __all__ = [
+    "ArrayLike1D",
     "BaseTemporalSplitter",
     "CombinatorialPurgedCV",
     "CombinatoriallySymmetricCV",
@@ -38,6 +40,7 @@ __all__ = [
     "PurgedKFold",
     "TemporalCVError",
     "TemporalLeakageError",
+    "TimesLike",
     "WalkForwardSplit",
     "__version__",
     "apply_embargo",

--- a/src/purgedcv/_base.py
+++ b/src/purgedcv/_base.py
@@ -15,7 +15,7 @@ from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_time
 from purgedcv._validation import _validate_positional_indices
 from purgedcv.diagnostics import assert_groups_disjoint
 
-from ._typing import NDArrayAny, TimesLike
+from ._typing import ArrayLike1D, NDArrayAny, TimesLike
 
 
 class BaseTemporalSplitter(ABC):
@@ -43,7 +43,7 @@ class BaseTemporalSplitter(ABC):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
-        groups: TimesLike | None = None,
+        groups: ArrayLike1D | None = None,
     ) -> None:
         pred = _coerce_1d(prediction_times, name="prediction_times")
         evalu = _coerce_1d(evaluation_times, name="evaluation_times")

--- a/src/purgedcv/_base.py
+++ b/src/purgedcv/_base.py
@@ -11,11 +11,11 @@ import pandas as pd
 
 from purgedcv._embargo import apply_embargo
 from purgedcv._purge import purge
-from purgedcv._time import HorizonLike, parse_horizon, validate_times
+from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
 from purgedcv._validation import _validate_positional_indices
 from purgedcv.diagnostics import assert_groups_disjoint
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 
 class BaseTemporalSplitter(ABC):
@@ -39,29 +39,32 @@ class BaseTemporalSplitter(ABC):
     def __init__(
         self,
         *,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
-        groups: pd.Series | None = None,
+        groups: TimesLike | None = None,
     ) -> None:
-        validate_times(prediction_times, evaluation_times, require_monotonic=True)
-        self._prediction_times = prediction_times.reset_index(drop=True)
-        self._evaluation_times = evaluation_times.reset_index(drop=True)
+        pred = _coerce_1d(prediction_times, name="prediction_times")
+        evalu = _coerce_1d(evaluation_times, name="evaluation_times")
+        validate_times(pred, evalu, require_monotonic=True)
+        self._prediction_times = pred
+        self._evaluation_times = evalu
         self.purge_horizon = (
             parse_horizon(purge_horizon) if purge_horizon is not None else pd.Timedelta(0)
         )
         self.embargo = parse_horizon(embargo) if embargo is not None else pd.Timedelta(0)
-        self._groups: pd.Series | None
+        self._groups: NDArrayAny | None
         if groups is not None:
-            if len(groups) != len(self._prediction_times):
+            groups_arr = _coerce_1d(groups, name="groups")
+            if len(groups_arr) != len(self._prediction_times):
                 raise ValueError(
-                    f"groups length {len(groups)} does not match "
+                    f"groups length {len(groups_arr)} does not match "
                     f"prediction_times length {len(self._prediction_times)}."
                 )
-            if groups.isna().any():
+            if pd.isna(groups_arr).any():
                 raise ValueError("groups contains missing values.")
-            self._groups = groups.reset_index(drop=True)
+            self._groups = groups_arr
         else:
             self._groups = None
 
@@ -136,8 +139,8 @@ class BaseTemporalSplitter(ABC):
 
     def with_times(
         self,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
     ) -> BaseTemporalSplitter:
         """Return a copy of this splitter with new times bound. All other
         parameters (``n_splits``, ``purge_horizon``, ``embargo``, ``groups``,
@@ -148,16 +151,18 @@ class BaseTemporalSplitter(ABC):
         fresh splitter via the constructor — this avoids surprising
         interactions between cached state and rebound inputs.
         """
-        validate_times(prediction_times, evaluation_times, require_monotonic=True)
-        if len(prediction_times) != len(self._prediction_times):
+        pred = _coerce_1d(prediction_times, name="prediction_times")
+        evalu = _coerce_1d(evaluation_times, name="evaluation_times")
+        validate_times(pred, evalu, require_monotonic=True)
+        if len(pred) != len(self._prediction_times):
             raise ValueError(
-                f"with_times got prediction_times of length {len(prediction_times)}; "
+                f"with_times got prediction_times of length {len(pred)}; "
                 f"this splitter was constructed for length "
                 f"{len(self._prediction_times)}."
             )
         new = copy.copy(self)
-        new._prediction_times = prediction_times.reset_index(drop=True)
-        new._evaluation_times = evaluation_times.reset_index(drop=True)
+        new._prediction_times = pred
+        new._evaluation_times = evalu
         return new
 
     def _n_samples_or_check(self, X: NDArrayAny | pd.DataFrame) -> int:  # noqa: N803

--- a/src/purgedcv/_cpcv.py
+++ b/src/purgedcv/_cpcv.py
@@ -20,7 +20,7 @@ from purgedcv._paths import reconstruct_paths
 from purgedcv._time import HorizonLike
 from purgedcv._validation import _validate_integer
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 
 class CombinatorialPurgedCV(BaseTemporalSplitter):
@@ -60,8 +60,8 @@ class CombinatorialPurgedCV(BaseTemporalSplitter):
         n_splits: int,
         n_test_groups: int,
         *,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:
@@ -315,8 +315,8 @@ class CombinatoriallySymmetricCV(CombinatorialPurgedCV):
         self,
         n_splits: int,
         *,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:

--- a/src/purgedcv/_embargo.py
+++ b/src/purgedcv/_embargo.py
@@ -10,17 +10,17 @@ import numpy as np
 import pandas as pd
 
 from purgedcv._intervals import points_in_any_closed_interval
-from purgedcv._time import validate_times
+from purgedcv._time import _coerce_1d, validate_times
 from purgedcv._validation import _validate_positional_indices
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 
 def apply_embargo(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
     embargo: pd.Timedelta,
 ) -> NDArrayAny:
     """Drop training rows whose ``prediction_time`` falls inside any closed
@@ -57,6 +57,8 @@ def apply_embargo(
         raise ValueError("embargo must be non-missing, got NaT.")
     if embargo < pd.Timedelta(0):
         raise ValueError(f"embargo must be non-negative, got {embargo}.")
+    prediction_times = _coerce_1d(prediction_times, name="prediction_times")
+    evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
@@ -66,9 +68,9 @@ def apply_embargo(
     if embargo == pd.Timedelta(0):
         return np.asarray(train_idx)
 
-    train_pred = prediction_times.iloc[train_idx].to_numpy()
-    embargo_starts = evaluation_times.iloc[test_idx].to_numpy()
-    embargo_ends = (evaluation_times.iloc[test_idx] + embargo).to_numpy()
+    train_pred = prediction_times[train_idx]
+    embargo_starts = evaluation_times[test_idx]
+    embargo_ends = evaluation_times[test_idx] + embargo
     in_embargo = points_in_any_closed_interval(train_pred, embargo_starts, embargo_ends)
     kept: NDArrayAny = train_idx[~in_embargo]
     return kept

--- a/src/purgedcv/_metrics.py
+++ b/src/purgedcv/_metrics.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 from scipy import stats
@@ -482,7 +483,7 @@ def min_track_record_length(
     return float(np.ceil(n_minus_1) + 1)
 
 
-def minimum_backtest_length(n_trials: int, target_sharpe: float = 1.0) -> float:
+def minimum_backtest_length(n_trials: int | np.integer[Any], target_sharpe: float = 1.0) -> float:
     r"""Minimum backtest length, in years, below which a high in-sample Sharpe
     is not evidence of skill once ``n_trials`` configurations were tried.
 

--- a/src/purgedcv/_path_metrics.py
+++ b/src/purgedcv/_path_metrics.py
@@ -156,4 +156,5 @@ def path_metrics(
     )
     rows = [dict(fn(arr[i])) for i in range(arr.shape[0])]
     index = pd.RangeIndex(arr.shape[0], name="path")
-    return pd.DataFrame(rows, index=index)
+    frame: pd.DataFrame = pd.DataFrame(rows, index=index)
+    return frame

--- a/src/purgedcv/_pbo.py
+++ b/src/purgedcv/_pbo.py
@@ -25,14 +25,13 @@ from dataclasses import dataclass
 from itertools import combinations
 
 import numpy as np
-import pandas as pd
 from scipy import stats
 
 from purgedcv._cpcv import CombinatorialPurgedCV
 from purgedcv._time import HorizonLike
 from purgedcv._validation import _validate_integer
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 #: A configuration-performance metric: maps a 1-D return slice to a scalar
 #: where larger is better. The default is :func:`sharpe`.
@@ -122,8 +121,8 @@ def _contiguous_blocks(n_obs: int, n_splits: int) -> list[NDArrayAny]:
 def _iter_is_oos(
     n_obs: int,
     n_splits: int,
-    prediction_times: pd.Series | None,
-    evaluation_times: pd.Series | None,
+    prediction_times: TimesLike | None,
+    evaluation_times: TimesLike | None,
     purge_horizon: HorizonLike | None,
     embargo: HorizonLike | None,
 ) -> Iterator[tuple[NDArrayAny, NDArrayAny]]:
@@ -164,7 +163,7 @@ def _iter_is_oos(
     yield from cv.split(placeholder)
 
 
-def _check_times_length(name: str, times: pd.Series | None, n_obs: int) -> None:
+def _check_times_length(name: str, times: TimesLike | None, n_obs: int) -> None:
     """Raise if an optional time series is present but the wrong length."""
     if times is not None and len(times) != n_obs:
         raise ValueError(f"{name} length {len(times)} does not match n_obs={n_obs}.")
@@ -173,8 +172,8 @@ def _check_times_length(name: str, times: pd.Series | None, n_obs: int) -> None:
 def _validate_pbo_inputs(
     returns: NDArrayAny,
     n_splits: int,
-    prediction_times: pd.Series | None,
-    evaluation_times: pd.Series | None,
+    prediction_times: TimesLike | None,
+    evaluation_times: TimesLike | None,
 ) -> tuple[NDArrayAny, int, int]:
     """Validate the PBO inputs and return ``(matrix, n_configs, n_obs)``."""
     if n_splits % 2 != 0:
@@ -263,8 +262,8 @@ def probability_of_backtest_overfitting(
     n_splits: int = 16,
     *,
     metric: PerformanceMetric = sharpe,
-    prediction_times: pd.Series | None = None,
-    evaluation_times: pd.Series | None = None,
+    prediction_times: TimesLike | None = None,
+    evaluation_times: TimesLike | None = None,
     purge_horizon: HorizonLike | None = None,
     embargo: HorizonLike | None = None,
 ) -> PBOResult:

--- a/src/purgedcv/_pbo.py
+++ b/src/purgedcv/_pbo.py
@@ -28,7 +28,7 @@ import numpy as np
 from scipy import stats
 
 from purgedcv._cpcv import CombinatorialPurgedCV
-from purgedcv._time import HorizonLike
+from purgedcv._time import HorizonLike, _coerce_1d
 from purgedcv._validation import _validate_integer
 
 from ._typing import NDArrayAny, TimesLike
@@ -314,17 +314,27 @@ def probability_of_backtest_overfitting(
         70
     """
     n_splits = _validate_integer("n_splits", n_splits, minimum=2)
-    matrix, n_configs, n_obs = _validate_pbo_inputs(
-        returns, n_splits, prediction_times, evaluation_times
+    # Normalize the optional time inputs once, up front, so both the length
+    # check and the split loop operate on validated 1-D numpy arrays. A scalar
+    # or 2-D input is rejected here with a clear message rather than failing
+    # later inside len().
+    pred = (
+        _coerce_1d(prediction_times, name="prediction_times")
+        if prediction_times is not None
+        else None
     )
+    evalu = (
+        _coerce_1d(evaluation_times, name="evaluation_times")
+        if evaluation_times is not None
+        else None
+    )
+    matrix, n_configs, n_obs = _validate_pbo_inputs(returns, n_splits, pred, evalu)
 
     logits: list[float] = []
     is_perf_best: list[float] = []
     oos_perf_best: list[float] = []
     n_dropped = 0
-    for is_idx, oos_idx in _iter_is_oos(
-        n_obs, n_splits, prediction_times, evaluation_times, purge_horizon, embargo
-    ):
+    for is_idx, oos_idx in _iter_is_oos(n_obs, n_splits, pred, evalu, purge_horizon, embargo):
         if len(is_idx) == 0 or len(oos_idx) == 0:
             n_dropped += 1
             continue

--- a/src/purgedcv/_purge.py
+++ b/src/purgedcv/_purge.py
@@ -10,17 +10,17 @@ import numpy as np
 import pandas as pd
 
 from purgedcv._intervals import overlaps_any_half_open_interval
-from purgedcv._time import validate_times
+from purgedcv._time import _coerce_1d, validate_times
 from purgedcv._validation import _validate_positional_indices
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 
 def purge(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
     purge_horizon: pd.Timedelta | None = None,
 ) -> NDArrayAny:
     """Drop training rows whose half-open label horizon overlaps any test horizon.
@@ -61,6 +61,8 @@ def purge(
         raise ValueError("purge_horizon must be non-missing, got NaT.")
     if horizon < pd.Timedelta(0):
         raise ValueError(f"purge_horizon must be non-negative, got {horizon}.")
+    prediction_times = _coerce_1d(prediction_times, name="prediction_times")
+    evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
@@ -68,10 +70,10 @@ def purge(
     if len(train_idx) == 0 or len(test_idx) == 0:
         return np.asarray(train_idx)
 
-    train_pred = prediction_times.iloc[train_idx].to_numpy()
-    train_eval = evaluation_times.iloc[train_idx].to_numpy()
-    test_starts = (prediction_times.iloc[test_idx] - horizon).to_numpy()
-    test_ends = (evaluation_times.iloc[test_idx] + horizon).to_numpy()
+    train_pred = prediction_times[train_idx]
+    train_eval = evaluation_times[train_idx]
+    test_starts = prediction_times[test_idx] - horizon
+    test_ends = evaluation_times[test_idx] + horizon
 
     keep = ~overlaps_any_half_open_interval(train_pred, train_eval, test_starts, test_ends)
     kept: NDArrayAny = train_idx[keep]

--- a/src/purgedcv/_purged_kfold.py
+++ b/src/purgedcv/_purged_kfold.py
@@ -14,7 +14,7 @@ from purgedcv._base import BaseTemporalSplitter
 from purgedcv._time import HorizonLike
 from purgedcv._validation import _validate_integer
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 
 class PurgedKFold(BaseTemporalSplitter):
@@ -58,8 +58,8 @@ class PurgedKFold(BaseTemporalSplitter):
         self,
         n_splits: int,
         *,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:
@@ -154,9 +154,9 @@ class PurgedGroupKFold(BaseTemporalSplitter):
         self,
         n_splits: int,
         *,
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
-        groups: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
+        groups: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:
@@ -190,7 +190,12 @@ class PurgedGroupKFold(BaseTemporalSplitter):
             embargo=embargo,
             groups=groups,
         )
-        unique = list(groups.unique())
+        if self._groups is None:  # bound at construction; should be unreachable
+            raise RuntimeError(
+                "PurgedGroupKFold._groups was unbound after construction. "
+                "This is an internal invariant violation."
+            )
+        unique = list(pd.unique(self._groups))
         if n_splits > len(unique):
             raise ValueError(
                 f"n_splits={n_splits} exceeds number of unique groups ({len(unique)})."
@@ -212,7 +217,7 @@ class PurgedGroupKFold(BaseTemporalSplitter):
                 "PurgedGroupKFold._groups was unbound at split time. "
                 "This is an internal invariant violation."
             )
-        groups_array = self._groups.to_numpy()
+        groups_array = np.asarray(self._groups)
         n_groups = len(self._unique_groups)
         block_size, remainder = divmod(n_groups, self.n_splits)
         cursor = 0

--- a/src/purgedcv/_purged_kfold.py
+++ b/src/purgedcv/_purged_kfold.py
@@ -14,7 +14,7 @@ from purgedcv._base import BaseTemporalSplitter
 from purgedcv._time import HorizonLike
 from purgedcv._validation import _validate_integer
 
-from ._typing import NDArrayAny, TimesLike
+from ._typing import ArrayLike1D, NDArrayAny, TimesLike
 
 
 class PurgedKFold(BaseTemporalSplitter):
@@ -156,7 +156,7 @@ class PurgedGroupKFold(BaseTemporalSplitter):
         *,
         prediction_times: TimesLike,
         evaluation_times: TimesLike,
-        groups: TimesLike,
+        groups: ArrayLike1D,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:

--- a/src/purgedcv/_time.py
+++ b/src/purgedcv/_time.py
@@ -51,7 +51,8 @@ def _coerce_1d(x: TimesLike, *, name: str) -> NDArrayAny:
         # constructor's overloads under mypy --strict.
         x_pandas: Any = x
         idx = pd.DatetimeIndex(x_pandas)  # accepts both Series and Index
-        return idx.tz_convert("UTC").tz_localize(None).to_numpy()
+        out: NDArrayAny = idx.tz_convert("UTC").tz_localize(None).to_numpy()
+        return out
     if isinstance(x, np.ndarray):
         arr: NDArrayAny = x
     elif hasattr(x, "to_numpy"):  # pandas Series/Index, polars Series
@@ -116,7 +117,8 @@ def parse_horizon(value: HorizonLike) -> pd.Timedelta:
     if td < pd.Timedelta(0):
         raise ValueError(f"Horizon must be non-negative, got {td}.")
 
-    return td
+    horizon: pd.Timedelta = td
+    return horizon
 
 
 def horizons_overlap(

--- a/src/purgedcv/_time.py
+++ b/src/purgedcv/_time.py
@@ -8,7 +8,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
-from ._typing import NDArrayAny, TimesLike
+from ._typing import NDArrayAny, SupportsToNumpy, TimesLike
 
 HorizonLike = str | pd.Timedelta | timedelta | np.timedelta64
 
@@ -55,11 +55,20 @@ def _coerce_1d(x: TimesLike, *, name: str) -> NDArrayAny:
         return out
     if isinstance(x, np.ndarray):
         arr: NDArrayAny = x
-    elif hasattr(x, "to_numpy"):  # pandas Series/Index, polars Series
+    elif isinstance(x, SupportsToNumpy):  # pandas Series/Index, polars Series
         arr = x.to_numpy()
     else:
         arr = np.asarray(x)
     arr = np.asarray(arr)
+    # Check dimensionality before the object/string coercion below: a 0-D
+    # scalar routed through ``pd.Series(...).to_numpy()`` would be reshaped to a
+    # length-1 1-D array and slip past this guard.
+    if arr.ndim != 1:
+        raise ValueError(
+            f"{name} must be a 1-D array-like; got a {arr.ndim}-D input of shape "
+            f"{arr.shape}. Pass a 1-D sequence, not a scalar or a 2-D array/"
+            f"DataFrame (select a single column first)."
+        )
     if arr.dtype == object or arr.dtype.kind in "US":
         arr = pd.Series(arr).to_numpy()
     return arr

--- a/src/purgedcv/_time.py
+++ b/src/purgedcv/_time.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype, is_timedelta64_dtype
+
+from ._typing import NDArrayAny, TimesLike
 
 HorizonLike = str | pd.Timedelta | timedelta | np.timedelta64
 
@@ -15,12 +17,51 @@ _AMBIGUOUS_OFFSETS = frozenset(
 )
 
 
-def _temporal_kind(values: pd.Series) -> str | None:
-    if is_datetime64_any_dtype(values.dtype):
+def _temporal_kind(arr: NDArrayAny) -> str | None:
+    if np.issubdtype(arr.dtype, np.datetime64):
         return "datetime"
-    if is_timedelta64_dtype(values.dtype):
+    if np.issubdtype(arr.dtype, np.timedelta64):
         return "timedelta"
     return None
+
+
+def _coerce_1d(x: TimesLike, *, name: str) -> NDArrayAny:
+    """Coerce any accepted time-like input to a 1-D numpy array.
+
+    Handles pandas ``Series`` / ``Index`` (including tz-aware), numpy
+    ``datetime64`` / ``timedelta64`` arrays, polars ``Series`` (duck-typed
+    via ``.to_numpy()``, never imported), and Python sequences of
+    ``datetime`` / ``Timestamp`` / ``datetime64`` / ``timedelta``.
+
+    tz-aware pandas input is converted to UTC and made tz-naive
+    ``datetime64``. Sequences that land as ``object`` dtype (or as numpy's
+    fixed-width string dtype, which is what a plain Python list of strings
+    becomes under ``np.asarray``) are routed through pandas so lists of
+    datetime/Timedelta objects resolve to ``datetime64`` / ``timedelta64``.
+    Inputs that stay ``object`` after that (for example a list of strings)
+    are returned as-is; ``validate_times`` then rejects them with a clear
+    dtype message. ``name`` is unused today but kept so future messages can
+    name the offending input.
+    """
+    dtype = getattr(x, "dtype", None)
+    if isinstance(dtype, pd.DatetimeTZDtype):
+        # x is a pandas Series/Index here (only those expose a real .dtype
+        # attribute equal to a DatetimeTZDtype instance); narrow explicitly
+        # since TimesLike's Sequence[Any] member confuses the DatetimeIndex
+        # constructor's overloads under mypy --strict.
+        x_pandas: Any = x
+        idx = pd.DatetimeIndex(x_pandas)  # accepts both Series and Index
+        return idx.tz_convert("UTC").tz_localize(None).to_numpy()
+    if isinstance(x, np.ndarray):
+        arr: NDArrayAny = x
+    elif hasattr(x, "to_numpy"):  # pandas Series/Index, polars Series
+        arr = x.to_numpy()
+    else:
+        arr = np.asarray(x)
+    arr = np.asarray(arr)
+    if arr.dtype == object or arr.dtype.kind in "US":
+        arr = pd.Series(arr).to_numpy()
+    return arr
 
 
 def parse_horizon(value: HorizonLike) -> pd.Timedelta:
@@ -121,8 +162,8 @@ def horizons_overlap(
 
 
 def validate_times(
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
     *,
     require_monotonic: bool = True,
 ) -> None:
@@ -141,13 +182,15 @@ def validate_times(
         >>> evalu = pred + pd.Timedelta(days=1)
         >>> validate_times(pred, evalu)
     """
-    if len(prediction_times) != len(evaluation_times):
+    pred = _coerce_1d(prediction_times, name="prediction_times")
+    evalu = _coerce_1d(evaluation_times, name="evaluation_times")
+    if len(pred) != len(evalu):
         raise ValueError(
-            f"length mismatch: prediction_times has {len(prediction_times)} rows, "
-            f"evaluation_times has {len(evaluation_times)} rows."
+            f"length mismatch: prediction_times has {len(pred)} rows, "
+            f"evaluation_times has {len(evalu)} rows."
         )
-    prediction_kind = _temporal_kind(prediction_times)
-    evaluation_kind = _temporal_kind(evaluation_times)
+    prediction_kind = _temporal_kind(pred)
+    evaluation_kind = _temporal_kind(evalu)
     if prediction_kind is None:
         raise ValueError("prediction_times must have a datetime-like or timedelta-like dtype.")
     if evaluation_kind is None:
@@ -156,16 +199,16 @@ def validate_times(
         raise ValueError(
             "prediction_times and evaluation_times must use the same temporal dtype family."
         )
-    if prediction_times.isna().any():
+    if np.isnat(pred).any():
         raise ValueError("prediction_times contains NaT values.")
-    if evaluation_times.isna().any():
+    if np.isnat(evalu).any():
         raise ValueError("evaluation_times contains NaT values.")
-    bad = evaluation_times.to_numpy() < prediction_times.to_numpy()
+    bad = evalu < pred
     if bad.any():
         first = int(bad.argmax())
         raise ValueError(
             f"evaluation_times falls before prediction_times at index {first}: "
-            f"{evaluation_times.iloc[first]} < {prediction_times.iloc[first]}."
+            f"{evalu[first]} < {pred[first]}."
         )
-    if require_monotonic and not prediction_times.is_monotonic_increasing:
+    if require_monotonic and not bool(np.all(pred[1:] >= pred[:-1])):
         raise ValueError("prediction_times must be monotonic non-decreasing.")

--- a/src/purgedcv/_time.py
+++ b/src/purgedcv/_time.py
@@ -40,8 +40,8 @@ def _coerce_1d(x: TimesLike, *, name: str) -> NDArrayAny:
     datetime/Timedelta objects resolve to ``datetime64`` / ``timedelta64``.
     Inputs that stay ``object`` after that (for example a list of strings)
     are returned as-is; ``validate_times`` then rejects them with a clear
-    dtype message. ``name`` is unused today but kept so future messages can
-    name the offending input.
+    dtype message. A 0-D (scalar) or 2-D input raises ``ValueError``. ``name``
+    labels the offending input in that error message.
     """
     dtype = getattr(x, "dtype", None)
     if isinstance(dtype, pd.DatetimeTZDtype):

--- a/src/purgedcv/_typing.py
+++ b/src/purgedcv/_typing.py
@@ -8,10 +8,21 @@ so the whole package annotates arrays with this alias instead of bare
 ``np.ndarray``.
 """
 
-from typing import Any, TypeAlias
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 #: Any numpy array. Equivalent in intent to the previously-used bare
 #: ``np.ndarray``; the explicit ``Any`` satisfies ``disallow_any_generics``.
 NDArrayAny: TypeAlias = npt.NDArray[Any]
+
+#: Any accepted time-like input at a public boundary. pandas ``Series`` /
+#: ``Index``, numpy ``datetime64`` / ``timedelta64`` arrays, Python sequences
+#: of datetime/Timestamp/datetime64/timedelta, and polars ``Series`` (matched
+#: by the trailing ``Any``, since polars is duck-typed and not importable at
+#: type-check time). Coerced to numpy by ``purgedcv._time._coerce_1d``.
+TimesLike: TypeAlias = "pd.Series | pd.Index | NDArrayAny | Sequence[Any] | Any"

--- a/src/purgedcv/_typing.py
+++ b/src/purgedcv/_typing.py
@@ -9,20 +9,45 @@ so the whole package annotates arrays with this alias instead of bare
 """
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import Any, Protocol, TypeAlias, runtime_checkable
 
 import numpy.typing as npt
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 #: Any numpy array. Equivalent in intent to the previously-used bare
 #: ``np.ndarray``; the explicit ``Any`` satisfies ``disallow_any_generics``.
 NDArrayAny: TypeAlias = npt.NDArray[Any]
 
-#: Any accepted time-like input at a public boundary. pandas ``Series`` /
-#: ``Index``, numpy ``datetime64`` / ``timedelta64`` arrays, Python sequences
-#: of datetime/Timestamp/datetime64/timedelta, and polars ``Series`` (matched
-#: by the trailing ``Any``, since polars is duck-typed and not importable at
-#: type-check time). Coerced to numpy by ``purgedcv._time._coerce_1d``.
-TimesLike: TypeAlias = "pd.Series | pd.Index | NDArrayAny | Sequence[Any] | Any"
+
+@runtime_checkable
+class SupportsToNumpy(Protocol):
+    """Structural type for a sized container exposing a zero-argument
+    ``.to_numpy()``.
+
+    pandas ``Series``/``Index`` and polars ``Series`` all satisfy this, so the
+    library accepts them without importing pandas as a typing requirement or
+    importing polars at all. numpy arrays do NOT define ``.to_numpy()``; they
+    are matched by the ``NDArrayAny`` arm of the array-like aliases below.
+    ``__len__`` is part of the contract because the library length-checks these
+    inputs before coercing them.
+    """
+
+    def __len__(self) -> int: ...
+
+    def to_numpy(self) -> NDArrayAny: ...
+
+
+#: A 1-D array-like of arbitrary elements: a numpy array, a Python sequence, or
+#: any object exposing ``.to_numpy()`` (pandas/polars). This is the container
+#: contract shared by time inputs and group labels; only the element semantics
+#: differ. Coerced to a 1-D numpy array by ``purgedcv._time._coerce_1d``.
+#:
+#: Unlike a bare ``Any``, this alias still rejects unrelated types (an ``int``,
+#: a mapping) statically, and it is a concrete ``Union`` object rather than a
+#: string, so ``typing.get_type_hints`` on the annotated public functions
+#: resolves without a ``NameError``.
+ArrayLike1D: TypeAlias = NDArrayAny | Sequence[Any] | SupportsToNumpy
+
+#: Time inputs (``prediction_times`` / ``evaluation_times``). The same
+#: containers as :data:`ArrayLike1D`; ``validate_times`` additionally requires
+#: the coerced array to hold a ``datetime64`` or ``timedelta64`` dtype.
+TimesLike: TypeAlias = ArrayLike1D

--- a/src/purgedcv/_walk_forward.py
+++ b/src/purgedcv/_walk_forward.py
@@ -12,7 +12,7 @@ from purgedcv._base import BaseTemporalSplitter
 from purgedcv._time import HorizonLike
 from purgedcv._validation import _validate_integer
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 WindowMode = Literal["sliding", "expanding"]
 
@@ -46,8 +46,8 @@ class WalkForwardSplit(BaseTemporalSplitter):
         *,
         train_size: int | None = None,
         window: WindowMode = "expanding",
-        prediction_times: pd.Series,
-        evaluation_times: pd.Series,
+        prediction_times: TimesLike,
+        evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
     ) -> None:

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -25,7 +25,7 @@ from purgedcv.exceptions import (
     TemporalLeakageError,
 )
 
-from ._typing import NDArrayAny, TimesLike
+from ._typing import ArrayLike1D, NDArrayAny, TimesLike
 
 __all__ = [
     "assert_embargo_respected",
@@ -151,7 +151,7 @@ def assert_embargo_respected(
 def assert_groups_disjoint(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    groups: TimesLike,
+    groups: ArrayLike1D,
 ) -> None:
     """Raise :class:`GroupLeakageError` if any group identifier appears in
     both ``train_idx`` and ``test_idx``.

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pandas as pd
 
 from purgedcv._intervals import overlaps_any_half_open_interval, points_in_any_closed_interval
-from purgedcv._time import HorizonLike, parse_horizon, validate_times
+from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
 from purgedcv._validation import _validate_positional_indices
 from purgedcv.exceptions import (
     EmbargoViolationError,
@@ -25,7 +25,7 @@ from purgedcv.exceptions import (
     TemporalLeakageError,
 )
 
-from ._typing import NDArrayAny
+from ._typing import NDArrayAny, TimesLike
 
 __all__ = [
     "assert_embargo_respected",
@@ -38,8 +38,8 @@ __all__ = [
 def assert_no_temporal_leakage(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
     *,
     purge_horizon: HorizonLike | None = None,
 ) -> None:
@@ -71,6 +71,8 @@ def assert_no_temporal_leakage(
         >>> assert_no_temporal_leakage(np.arange(5), np.arange(10, 15), pred, evalu)
     """
     horizon = parse_horizon(purge_horizon) if purge_horizon is not None else pd.Timedelta(0)
+    prediction_times = _coerce_1d(prediction_times, name="prediction_times")
+    evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
@@ -78,10 +80,10 @@ def assert_no_temporal_leakage(
     if len(train_idx) == 0 or len(test_idx) == 0:
         return
 
-    train_pred = prediction_times.iloc[train_idx].to_numpy()
-    train_eval = evaluation_times.iloc[train_idx].to_numpy()
-    test_starts = (prediction_times.iloc[test_idx] - horizon).to_numpy()
-    test_ends = (evaluation_times.iloc[test_idx] + horizon).to_numpy()
+    train_pred = prediction_times[train_idx]
+    train_eval = evaluation_times[train_idx]
+    test_starts = prediction_times[test_idx] - horizon
+    test_ends = evaluation_times[test_idx] + horizon
 
     overlaps = overlaps_any_half_open_interval(train_pred, train_eval, test_starts, test_ends)
     if overlaps.any():
@@ -97,8 +99,8 @@ def assert_no_temporal_leakage(
 def assert_embargo_respected(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
     embargo: HorizonLike,
 ) -> None:
     """Raise :class:`EmbargoViolationError` if any training row's
@@ -121,6 +123,8 @@ def assert_embargo_respected(
         ... )
     """
     emb = parse_horizon(embargo)
+    prediction_times = _coerce_1d(prediction_times, name="prediction_times")
+    evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
@@ -130,9 +134,9 @@ def assert_embargo_respected(
     if emb == pd.Timedelta(0):
         return
 
-    train_pred = prediction_times.iloc[train_idx].to_numpy()
-    embargo_starts = evaluation_times.iloc[test_idx].to_numpy()
-    embargo_ends = (evaluation_times.iloc[test_idx] + emb).to_numpy()
+    train_pred = prediction_times[train_idx]
+    embargo_starts = evaluation_times[test_idx]
+    embargo_ends = evaluation_times[test_idx] + emb
     in_embargo = points_in_any_closed_interval(train_pred, embargo_starts, embargo_ends)
     if in_embargo.any():
         first_local = int(in_embargo.argmax())
@@ -147,7 +151,7 @@ def assert_embargo_respected(
 def assert_groups_disjoint(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    groups: pd.Series,
+    groups: TimesLike,
 ) -> None:
     """Raise :class:`GroupLeakageError` if any group identifier appears in
     both ``train_idx`` and ``test_idx``.
@@ -164,16 +168,17 @@ def assert_groups_disjoint(
         >>> groups = pd.Series([0, 0, 1, 1, 2, 2])
         >>> assert_groups_disjoint(np.array([0, 1]), np.array([2, 3]), groups)
     """
+    groups = _coerce_1d(groups, name="groups")
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=len(groups))
     test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=len(groups))
     if len(train_idx) == 0 or len(test_idx) == 0:
         return
-    train_group_values = groups.iloc[train_idx]
-    test_group_values = groups.iloc[test_idx]
-    if train_group_values.isna().any() or test_group_values.isna().any():
+    train_group_values = groups[train_idx]
+    test_group_values = groups[test_idx]
+    if pd.isna(train_group_values).any() or pd.isna(test_group_values).any():
         raise ValueError("groups contains missing values in train or test indices.")
-    train_groups = set(train_group_values.unique())
-    test_groups = set(test_group_values.unique())
+    train_groups = set(train_group_values.tolist())
+    test_groups = set(test_group_values.tolist())
     overlap = train_groups & test_groups
     if overlap:
         offender = next(iter(sorted(overlap, key=str)))
@@ -186,8 +191,8 @@ def assert_groups_disjoint(
 def compute_overlap_fraction(
     train_idx: NDArrayAny,
     test_idx: NDArrayAny,
-    prediction_times: pd.Series,
-    evaluation_times: pd.Series,
+    prediction_times: TimesLike,
+    evaluation_times: TimesLike,
 ) -> float:
     """Return the fraction of training rows whose half-open label horizon
     overlaps any test horizon.
@@ -210,15 +215,17 @@ def compute_overlap_fraction(
         ... )
         1.0
     """
+    prediction_times = _coerce_1d(prediction_times, name="prediction_times")
+    evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
     test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=n_samples)
     if len(train_idx) == 0 or len(test_idx) == 0:
         return 0.0
-    train_pred = prediction_times.iloc[train_idx].to_numpy()
-    train_eval = evaluation_times.iloc[train_idx].to_numpy()
-    test_starts = prediction_times.iloc[test_idx].to_numpy()
-    test_ends = evaluation_times.iloc[test_idx].to_numpy()
+    train_pred = prediction_times[train_idx]
+    train_eval = evaluation_times[train_idx]
+    test_starts = prediction_times[test_idx]
+    test_ends = evaluation_times[test_idx]
     overlaps = overlaps_any_half_open_interval(train_pred, train_eval, test_starts, test_ends)
     return float(overlaps.mean())

--- a/tests/e2e/test_e2e_framework_agnostic_times.py
+++ b/tests/e2e/test_e2e_framework_agnostic_times.py
@@ -1,0 +1,88 @@
+"""End-to-end tests for framework-agnostic time inputs.
+
+User stories:
+- A quant whose pipeline is numpy-only builds a purged splitter without ever
+  constructing a pandas object.
+- A quant who has migrated to polars extracts two time columns and runs CPCV
+  to completion.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.mark.e2e
+def test_subprocess_numpy_only_split_runs_clean() -> None:
+    snippet = textwrap.dedent("""\
+        import numpy as np
+        from purgedcv import PurgedKFold
+        n = 24
+        pred = np.arange("2024-01-01", "2024-01-25", dtype="datetime64[D]")
+        evalu = pred + np.timedelta64(1, "D")
+        X = np.zeros((n, 1))
+        sp = PurgedKFold(n_splits=3, prediction_times=pred, evaluation_times=evalu, purge_horizon="1D")
+        folds = list(sp.split(X))
+        assert len(folds) == 3
+        for tr, te in folds:
+            assert set(tr).isdisjoint(set(te))
+        print("OK")
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == "OK"
+    assert result.stderr == ""
+
+
+@pytest.mark.e2e
+def test_user_story_polars_quant_runs_cpcv() -> None:
+    pl = pytest.importorskip("polars")
+    from purgedcv import CombinatorialPurgedCV
+
+    n = 60
+    ts = pd.date_range("2024-01-01", periods=n, freq="D")
+    df = pl.DataFrame(
+        {
+            "prediction_time": ts,
+            "evaluation_time": ts + pd.Timedelta(days=3),
+            "feature": np.arange(n, dtype=float),
+        }
+    )
+    splitter = CombinatorialPurgedCV(
+        n_splits=6,
+        n_test_groups=2,
+        prediction_times=df["prediction_time"],
+        evaluation_times=df["evaluation_time"],
+        purge_horizon="1D",
+    )
+    X = df.select("feature").to_numpy()  # noqa: N806
+    folds = list(splitter.split(X))
+    assert len(folds) == 15  # C(6, 2)
+    for train_idx, test_idx in folds:
+        assert set(train_idx).isdisjoint(set(test_idx))
+
+
+@pytest.mark.e2e
+def test_user_story_numpy_and_pandas_agree() -> None:
+    from purgedcv import PurgedKFold
+
+    n = 40
+    pred_pd = pd.Series(pd.date_range("2024-01-01", periods=n, freq="D"))
+    evalu_pd = pred_pd + pd.Timedelta(days=2)
+    X = np.zeros((n, 1))  # noqa: N806
+    a = list(PurgedKFold(n_splits=5, prediction_times=pred_pd, evaluation_times=evalu_pd).split(X))
+    b = list(
+        PurgedKFold(
+            n_splits=5, prediction_times=pred_pd.to_numpy(), evaluation_times=evalu_pd.to_numpy()
+        ).split(X)
+    )
+    for (tr_a, te_a), (tr_b, te_b) in zip(a, b, strict=True):
+        np.testing.assert_array_equal(tr_a, tr_b)
+        np.testing.assert_array_equal(te_a, te_b)

--- a/tests/e2e/test_e2e_walk_forward.py
+++ b/tests/e2e/test_e2e_walk_forward.py
@@ -58,8 +58,8 @@ def test_user_story_with_times_adapter() -> None:
     X = np.zeros((50, 1))  # noqa: N806
     # Verify the rebind actually happened: a bug where with_times silently
     # returned self would leave cv2._prediction_times pointing at pred1.
-    assert cv2._prediction_times.iloc[0] == pred2.iloc[0]
-    assert cv2._evaluation_times.iloc[0] == evalu2.iloc[0]
+    assert cv2._prediction_times[0] == pred2.iloc[0]
+    assert cv2._evaluation_times[0] == evalu2.iloc[0]
     # And the diagnostic against the new times must still succeed:
     for train_idx, test_idx in cv2.split(X):
         assert_no_temporal_leakage(train_idx, test_idx, pred2, evalu2)

--- a/tests/test_base_splitter.py
+++ b/tests/test_base_splitter.py
@@ -36,8 +36,8 @@ class _GroupRespectingStub(BaseTemporalSplitter):
 
     def _iter_test_indices(self, n_samples: int) -> list[NDArrayAny]:
         assert self._groups is not None  # by construction in the test
-        groups_array = self._groups.to_numpy()
-        return [np.where(groups_array == g)[0] for g in self._groups.unique()]
+        groups_array = np.asarray(self._groups)
+        return [np.where(groups_array == g)[0] for g in pd.unique(self._groups)]
 
     def get_n_splits(
         self,
@@ -46,7 +46,7 @@ class _GroupRespectingStub(BaseTemporalSplitter):
         groups: object = None,
     ) -> int:
         assert self._groups is not None
-        return int(self._groups.nunique())
+        return len(pd.unique(self._groups))
 
 
 class _LeakyStub(BaseTemporalSplitter):
@@ -146,13 +146,16 @@ class TestBaseTemporalSplitterSkeleton:
             )
 
     def test_constructor_resets_series_index(self) -> None:
-        """Stored times must use a 0-based integer index regardless of input."""
+        """Stored times are coerced to numpy, so any custom pandas index on
+        the input is dropped rather than leaking into the stored positions."""
         idx = pd.RangeIndex(start=5, stop=25)
         pred = pd.Series(pd.date_range("2024-01-01", periods=20, freq="D"), index=idx)
         evalu = pred + pd.Timedelta(days=1)
         cv = _TwoFoldStub(prediction_times=pred, evaluation_times=evalu)
-        assert list(cv._prediction_times.index) == list(range(20))
-        assert list(cv._evaluation_times.index) == list(range(20))
+        assert isinstance(cv._prediction_times, np.ndarray)
+        assert isinstance(cv._evaluation_times, np.ndarray)
+        np.testing.assert_array_equal(cv._prediction_times, pred.to_numpy())
+        np.testing.assert_array_equal(cv._evaluation_times, evalu.to_numpy())
 
 
 class TestBaseTemporalSplitterSplit:
@@ -257,9 +260,9 @@ class TestBaseTemporalSplitterWithTimes:
         # New instance, not the same object.
         assert cv2 is not cv
         # Times rebound.
-        assert cv2._prediction_times.iloc[0] == pd.Timestamp("2025-01-01")
+        assert cv2._prediction_times[0] == pd.Timestamp("2025-01-01")
         # Original unchanged.
-        assert cv._prediction_times.iloc[0] == pd.Timestamp("2024-01-01")
+        assert cv._prediction_times[0] == pd.Timestamp("2024-01-01")
         # Other attributes preserved.
         assert cv2.purge_horizon == cv.purge_horizon
         assert cv2.embargo == cv.embargo
@@ -306,7 +309,7 @@ class TestBaseTemporalSplitterWithTimes:
         # _groups attribute is preserved by reference (shallow copy).
         assert cv2._groups is not None
         assert cv._groups is not None
-        pd.testing.assert_series_equal(cv2._groups, cv._groups)
+        np.testing.assert_array_equal(cv2._groups, cv._groups)
 
 
 class TestBaseTemporalSplitterGroups:
@@ -347,3 +350,20 @@ class TestBaseTemporalSplitterGroups:
         X = np.zeros((20, 1))  # noqa: N806
         with pytest.raises(GroupLeakageError):
             list(cv.split(X))
+
+
+def test_splitter_from_numpy_inputs_matches_pandas() -> None:
+    from purgedcv import PurgedKFold
+
+    n = 30
+    pred_pd = pd.Series(pd.date_range("2024-01-01", periods=n, freq="D"))
+    evalu_pd = pred_pd + pd.Timedelta(days=2)
+    X = np.zeros((n, 1))  # noqa: N806
+
+    sp_pd = PurgedKFold(n_splits=3, prediction_times=pred_pd, evaluation_times=evalu_pd)
+    sp_np = PurgedKFold(
+        n_splits=3, prediction_times=pred_pd.to_numpy(), evaluation_times=evalu_pd.to_numpy()
+    )
+    for (tr_pd, te_pd), (tr_np, te_np) in zip(sp_pd.split(X), sp_np.split(X), strict=True):
+        np.testing.assert_array_equal(tr_pd, tr_np)
+        np.testing.assert_array_equal(te_pd, te_np)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -309,3 +309,32 @@ class TestComputeOverlapFraction:
         train_idx = np.array([3, 4, 5, 6, 7, 8])
         test_idx = np.array([0, 1, 2, 9, 10, 11])
         assert compute_overlap_fraction(train_idx, test_idx, pred, evalu) == 0.0
+
+
+def test_compute_overlap_fraction_numpy_matches_pandas() -> None:
+    from purgedcv.diagnostics import compute_overlap_fraction
+
+    pred = pd.Series(pd.date_range("2024-01-01", periods=20, freq="D"))
+    evalu = pred + pd.Timedelta(days=1)
+    train = np.arange(0, 10)
+    test = np.arange(10, 15)
+    f_pd = compute_overlap_fraction(train, test, pred, evalu)
+    f_np = compute_overlap_fraction(train, test, pred.to_numpy(), evalu.to_numpy())
+    assert f_pd == f_np
+
+
+def test_assert_groups_disjoint_accepts_numpy_and_detects_overlap() -> None:
+    from purgedcv.diagnostics import assert_groups_disjoint
+    from purgedcv.exceptions import GroupLeakageError
+
+    groups = np.array([0, 0, 1, 1, 2, 2])
+    assert_groups_disjoint(np.array([0, 1]), np.array([4, 5]), groups)  # clean
+    with pytest.raises(GroupLeakageError):
+        assert_groups_disjoint(np.array([0, 1]), np.array([1, 2]), groups)
+
+
+def test_assert_groups_disjoint_string_numpy_groups() -> None:
+    from purgedcv.diagnostics import assert_groups_disjoint
+
+    groups = np.array(["a", "a", "b", "b"])
+    assert_groups_disjoint(np.array([0, 1]), np.array([2, 3]), groups)

--- a/tests/test_embargo.py
+++ b/tests/test_embargo.py
@@ -159,3 +159,17 @@ class TestApplyEmbargo:
         # test block.
         expected = np.array([5, 6, 7, 8])
         np.testing.assert_array_equal(result, expected)
+
+
+def test_apply_embargo_numpy_matches_pandas() -> None:
+    from purgedcv import apply_embargo
+
+    pred_pd = pd.Series(pd.date_range("2024-01-01", periods=20, freq="D"))
+    evalu_pd = pred_pd + pd.Timedelta(days=1)
+    train_idx = np.array([11, 12, 13, 14])
+    test_idx = np.arange(5, 10)
+    out_pd = apply_embargo(train_idx, test_idx, pred_pd, evalu_pd, pd.Timedelta(days=1))
+    out_np = apply_embargo(
+        train_idx, test_idx, pred_pd.to_numpy(), evalu_pd.to_numpy(), pd.Timedelta(days=1)
+    )
+    np.testing.assert_array_equal(out_pd, out_np)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -687,6 +687,4 @@ class TestMinimumBacktestLength:
     def test_accepts_numpy_integer(self) -> None:
         """A numpy integer (the natural type from len(study.trials) wrappers)
         is accepted like a Python int."""
-        assert minimum_backtest_length(np.int64(10)) == pytest.approx(  # type: ignore[arg-type]
-            minimum_backtest_length(10)
-        )
+        assert minimum_backtest_length(np.int64(10)) == pytest.approx(minimum_backtest_length(10))

--- a/tests/test_pbo.py
+++ b/tests/test_pbo.py
@@ -183,3 +183,27 @@ class TestPBOValidation:
                 n_splits=4,
                 metric=lambda r: r[:2],  # type: ignore[arg-type,return-value]
             )
+
+
+def test_pbo_rejects_scalar_times() -> None:
+    """A 0-D time input is rejected with the 1-D message, not a len() TypeError."""
+    rng = np.random.default_rng(0)
+    returns = rng.normal(size=(4, 40))
+    with pytest.raises(ValueError, match="1-D array-like"):
+        probability_of_backtest_overfitting(
+            returns,
+            n_splits=4,
+            prediction_times=np.datetime64("2024-01-01"),  # type: ignore[arg-type]
+            evaluation_times=np.datetime64("2024-01-02"),  # type: ignore[arg-type]
+        )
+
+
+def test_pbo_rejects_2d_times() -> None:
+    """A 2-D (n, 1) time input is rejected up front, not deep in the split loop."""
+    rng = np.random.default_rng(0)
+    returns = rng.normal(size=(4, 40))
+    pred = pd.date_range("2024-01-01", periods=40, freq="D").to_numpy().reshape(-1, 1)
+    with pytest.raises(ValueError, match="1-D array-like"):
+        probability_of_backtest_overfitting(
+            returns, n_splits=4, prediction_times=pred, evaluation_times=pred
+        )

--- a/tests/test_pbo.py
+++ b/tests/test_pbo.py
@@ -193,8 +193,8 @@ def test_pbo_rejects_scalar_times() -> None:
         probability_of_backtest_overfitting(
             returns,
             n_splits=4,
-            prediction_times=np.datetime64("2024-01-01"),  # type: ignore[arg-type]
-            evaluation_times=np.datetime64("2024-01-02"),  # type: ignore[arg-type]
+            prediction_times=np.datetime64("2024-01-01"),  # type: ignore[arg-type, unused-ignore]
+            evaluation_times=np.datetime64("2024-01-02"),  # type: ignore[arg-type, unused-ignore]
         )
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import numpy as np
+import pandas as pd
 import pytest
 
 import purgedcv
@@ -125,3 +127,22 @@ def test_subprocess_can_import_every_public_name() -> None:
     )
     assert result.stdout.strip() == "OK"
     assert result.stderr == ""
+
+
+def test_splitters_accept_numpy_times_no_typeerror() -> None:
+    import purgedcv as pcv
+
+    n = 18
+    pred = pd.date_range("2024-01-01", periods=n, freq="D").to_numpy()
+    evalu = pred + np.timedelta64(1, "D")
+    X = np.zeros((n, 1))  # noqa: N806
+    for splitter in (
+        pcv.PurgedKFold(n_splits=3, prediction_times=pred, evaluation_times=evalu),
+        pcv.CombinatorialPurgedCV(
+            n_splits=4, n_test_groups=2, prediction_times=pred, evaluation_times=evalu
+        ),
+        pcv.WalkForwardSplit(
+            n_splits=3, test_size=2, prediction_times=pred, evaluation_times=evalu
+        ),
+    ):
+        assert len(list(splitter.split(X))) >= 1

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,6 +21,7 @@ EXPECTED_TOP_LEVEL: frozenset[str] = frozenset(
     {
         "__version__",
         "apply_embargo",
+        "ArrayLike1D",
         "BaseTemporalSplitter",
         "CombinatorialPurgedCV",
         "CombinatoriallySymmetricCV",
@@ -44,6 +45,7 @@ EXPECTED_TOP_LEVEL: frozenset[str] = frozenset(
         "PurgedKFold",
         "TemporalCVError",
         "TemporalLeakageError",
+        "TimesLike",
         "validate_times",
         "WalkForwardSplit",
     }

--- a/tests/test_purge.py
+++ b/tests/test_purge.py
@@ -237,3 +237,15 @@ class TestPurgeAFMLSnippet71:
 
         expected = np.array([0, 1])
         np.testing.assert_array_equal(result, expected)
+
+
+def test_purge_numpy_matches_pandas() -> None:
+    from purgedcv import purge
+
+    pred_pd = pd.Series(pd.date_range("2024-01-01", periods=10, freq="D"))
+    evalu_pd = pred_pd + pd.Timedelta(days=3)
+    train_idx = np.array([0, 1, 2, 3, 4, 8, 9])
+    test_idx = np.array([5, 6, 7])
+    out_pd = purge(train_idx, test_idx, pred_pd, evalu_pd)
+    out_np = purge(train_idx, test_idx, pred_pd.to_numpy(), evalu_pd.to_numpy())
+    np.testing.assert_array_equal(out_pd, out_np)

--- a/tests/test_purged_kfold.py
+++ b/tests/test_purged_kfold.py
@@ -244,3 +244,20 @@ class TestPurgedGroupKFold:
                     evaluation_times=evalu,
                     groups=groups,
                 )
+
+
+def test_purged_group_kfold_accepts_numpy_groups() -> None:
+    from purgedcv import PurgedGroupKFold
+
+    n = 12
+    pred = pd.date_range("2024-01-01", periods=n, freq="D").to_numpy()
+    evalu = pred + np.timedelta64(1, "D")
+    groups = np.repeat(np.arange(4), 3)  # 0,0,0,1,1,1,2,2,2,3,3,3
+    splitter = PurgedGroupKFold(
+        n_splits=2, prediction_times=pred, evaluation_times=evalu, groups=groups
+    )
+    folds = list(splitter.split(np.zeros((n, 1))))
+    assert len(folds) == 2
+    # every index assigned to some test fold, none shared
+    all_test = np.concatenate([test for _, test in folds])
+    assert sorted(all_test.tolist()) == list(range(n))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -343,13 +343,13 @@ class TestCoerce1dDimensionality:
         from purgedcv._time import _coerce_1d
 
         with pytest.raises(ValueError, match="1-D array-like"):
-            _coerce_1d(np.datetime64("2024-01-01"), name="prediction_times")  # type: ignore[arg-type]
+            _coerce_1d(np.datetime64("2024-01-01"), name="prediction_times")  # type: ignore[arg-type, unused-ignore]
 
     def test_rejects_pandas_timestamp_scalar(self) -> None:
         from purgedcv._time import _coerce_1d
 
         with pytest.raises(ValueError, match="1-D array-like"):
-            _coerce_1d(pd.Timestamp("2024-01-01"), name="prediction_times")  # type: ignore[arg-type]
+            _coerce_1d(pd.Timestamp("2024-01-01"), name="prediction_times")  # type: ignore[arg-type, unused-ignore]
 
     def test_rejects_dataframe(self) -> None:
         from purgedcv._time import _coerce_1d

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -212,3 +212,120 @@ class TestValidateTimes:
         evalu = pred + pd.Timedelta(days=1)
         with pytest.raises(ValueError, match="monotonic"):
             validate_times(pred, evalu, require_monotonic=True)
+
+
+class TestCoerce1d:
+    def test_numpy_datetime64_passthrough(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        arr = np.array(["2024-01-01", "2024-01-02"], dtype="datetime64[ns]")
+        out = _coerce_1d(arr, name="t")
+        assert np.issubdtype(out.dtype, np.datetime64)
+        np.testing.assert_array_equal(out, arr)
+
+    def test_numpy_timedelta64_passthrough(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        arr = np.array([1, 2], dtype="timedelta64[D]")
+        out = _coerce_1d(arr, name="t")
+        assert np.issubdtype(out.dtype, np.timedelta64)
+
+    def test_pandas_series_to_numpy(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        s = pd.Series(pd.date_range("2024-01-01", periods=3, freq="D"))
+        out = _coerce_1d(s, name="t")
+        assert np.issubdtype(out.dtype, np.datetime64)
+        assert len(out) == 3
+
+    def test_datetimeindex(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        idx = pd.date_range("2024-01-01", periods=3, freq="D")
+        out = _coerce_1d(idx, name="t")
+        assert np.issubdtype(out.dtype, np.datetime64)
+
+    def test_list_of_timestamps(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        out = _coerce_1d([pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")], name="t")
+        assert np.issubdtype(out.dtype, np.datetime64)
+
+    def test_list_of_timedeltas(self) -> None:
+        from datetime import timedelta
+
+        from purgedcv._time import _coerce_1d
+
+        out = _coerce_1d([timedelta(days=1), timedelta(days=2)], name="t")
+        assert np.issubdtype(out.dtype, np.timedelta64)
+
+    def test_tz_aware_normalized_to_utc_naive(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        s = pd.Series(pd.date_range("2024-01-01", periods=2, freq="D", tz="US/Eastern"))
+        out = _coerce_1d(s, name="t")
+        assert np.issubdtype(out.dtype, np.datetime64)
+        # 2024-01-01 00:00 US/Eastern == 2024-01-01 05:00 UTC
+        assert out[0] == np.datetime64("2024-01-01T05:00:00")
+
+    def test_object_list_of_strings_stays_object(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        out = _coerce_1d(["2024-01-01", "2024-01-02"], name="t")
+        assert out.dtype == object
+
+
+class TestValidateTimesInputTypes:
+    def test_numpy_datetime64_ok(self) -> None:
+        from purgedcv import validate_times
+
+        pred = pd.date_range("2024-01-01", periods=5, freq="D").to_numpy()
+        evalu = pred + np.timedelta64(1, "D")
+        validate_times(pred, evalu)
+
+    def test_numpy_timedelta64_ok(self) -> None:
+        from purgedcv import validate_times
+
+        pred = np.array([1, 2, 3], dtype="timedelta64[D]")
+        evalu = np.array([2, 3, 4], dtype="timedelta64[D]")
+        validate_times(pred, evalu)
+
+    def test_list_input_ok(self) -> None:
+        from purgedcv import validate_times
+
+        pred = [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")]
+        evalu = [pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")]
+        validate_times(pred, evalu)
+
+    def test_mixed_kind_rejected(self) -> None:
+        from purgedcv import validate_times
+
+        pred = pd.date_range("2024-01-01", periods=3, freq="D").to_numpy()
+        evalu = np.array([1, 2, 3], dtype="timedelta64[D]")
+        with pytest.raises(ValueError, match="same temporal dtype family"):
+            validate_times(pred, evalu)
+
+    def test_non_temporal_rejected(self) -> None:
+        from purgedcv import validate_times
+
+        with pytest.raises(ValueError, match="datetime-like or timedelta-like"):
+            validate_times([1, 2, 3], [2, 3, 4])
+
+    def test_nat_in_numpy_rejected(self) -> None:
+        from purgedcv import validate_times
+
+        pred = np.array(["2024-01-01", "NaT"], dtype="datetime64[ns]")
+        evalu = np.array(["2024-01-02", "2024-01-03"], dtype="datetime64[ns]")
+        with pytest.raises(ValueError, match="NaT"):
+            validate_times(pred, evalu, require_monotonic=False)
+
+    def test_inverted_row_message_has_date(self) -> None:
+        from purgedcv import validate_times
+
+        pred = np.array(["2024-01-01", "2024-01-10"], dtype="datetime64[ns]")
+        evalu = np.array(["2024-01-02", "2024-01-09"], dtype="datetime64[ns]")
+        with pytest.raises(ValueError) as exc:
+            validate_times(pred, evalu, require_monotonic=False)
+        msg = str(exc.value)
+        assert "index 1" in msg
+        assert "2024-01-09" in msg

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -329,3 +329,85 @@ class TestValidateTimesInputTypes:
         msg = str(exc.value)
         assert "index 1" in msg
         assert "2024-01-09" in msg
+
+
+class TestCoerce1dDimensionality:
+    def test_rejects_2d_array(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        arr = np.arange(10).reshape(-1, 1)
+        with pytest.raises(ValueError, match="1-D array-like"):
+            _coerce_1d(arr, name="prediction_times")
+
+    def test_rejects_0d_numpy_scalar(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        with pytest.raises(ValueError, match="1-D array-like"):
+            _coerce_1d(np.datetime64("2024-01-01"), name="prediction_times")  # type: ignore[arg-type]
+
+    def test_rejects_pandas_timestamp_scalar(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        with pytest.raises(ValueError, match="1-D array-like"):
+            _coerce_1d(pd.Timestamp("2024-01-01"), name="prediction_times")  # type: ignore[arg-type]
+
+    def test_rejects_dataframe(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        df = pd.DataFrame({"t": pd.date_range("2024-01-01", periods=5, freq="D")})
+        with pytest.raises(ValueError, match="1-D array-like"):
+            _coerce_1d(df, name="prediction_times")
+
+    def test_message_names_the_input_and_shape(self) -> None:
+        from purgedcv._time import _coerce_1d
+
+        arr = np.arange(6).reshape(-1, 1)
+        with pytest.raises(ValueError) as exc:
+            _coerce_1d(arr, name="groups")
+        msg = str(exc.value)
+        assert "groups" in msg
+        assert "2-D" in msg
+
+
+class TestDimensionalityAtPublicBoundary:
+    def test_validate_times_rejects_2d(self) -> None:
+        pred = pd.Series(pd.date_range("2024-01-01", periods=10, freq="D")).to_numpy()
+        with pytest.raises(ValueError, match="1-D array-like"):
+            validate_times(pred.reshape(-1, 1), pred.reshape(-1, 1))
+
+    def test_splitter_rejects_2d_times(self) -> None:
+        from purgedcv import PurgedKFold
+
+        pred = pd.Series(pd.date_range("2024-01-01", periods=10, freq="D")).to_numpy()
+        with pytest.raises(ValueError, match="1-D array-like"):
+            PurgedKFold(
+                n_splits=3,
+                prediction_times=pred.reshape(-1, 1),
+                evaluation_times=pred.reshape(-1, 1),
+            )
+
+    def test_group_splitter_rejects_2d_groups(self) -> None:
+        from purgedcv import PurgedGroupKFold
+
+        n = 9
+        pred = pd.date_range("2024-01-01", periods=n, freq="D").to_numpy()
+        evalu = pred + np.timedelta64(1, "D")
+        groups = np.repeat(np.arange(3), 3).reshape(-1, 1)
+        with pytest.raises(ValueError, match="1-D array-like"):
+            PurgedGroupKFold(
+                n_splits=2, prediction_times=pred, evaluation_times=evalu, groups=groups
+            )
+
+
+class TestRuntimeIntrospection:
+    def test_get_type_hints_resolves_on_public_functions(self) -> None:
+        import typing
+
+        from purgedcv import apply_embargo, purge, validate_times
+
+        # Regression: TimesLike used to be a string alias referencing names not
+        # present in these modules' namespaces, so get_type_hints raised
+        # NameError. It is now a concrete Union and must resolve cleanly.
+        for fn in (validate_times, purge, apply_embargo):
+            hints = typing.get_type_hints(fn)
+            assert "prediction_times" in hints

--- a/tests/test_time_properties.py
+++ b/tests/test_time_properties.py
@@ -29,7 +29,8 @@ def timestamps(draw: st.DrawFn) -> pd.Timestamp:
             max_value=datetime(2050, 12, 31),
         )
     )
-    return pd.Timestamp(dt)
+    ts: pd.Timestamp = pd.Timestamp(dt)
+    return ts
 
 
 @st.composite

--- a/tests/test_times_input_types.py
+++ b/tests/test_times_input_types.py
@@ -1,0 +1,85 @@
+"""Equivalence: every accepted time-input container yields identical results."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from purgedcv import PurgedKFold, apply_embargo, purge
+from purgedcv._typing import NDArrayAny, TimesLike
+from purgedcv.diagnostics import compute_overlap_fraction
+
+N = 40
+_PRED_PD = pd.Series(pd.date_range("2024-01-01", periods=N, freq="D"))
+_EVAL_PD = _PRED_PD + pd.Timedelta(days=2)
+_TRAIN = np.arange(0, 20)
+_TEST = np.arange(25, 30)
+
+
+def _variants() -> dict[str, tuple[TimesLike, TimesLike]]:
+    variants: dict[str, tuple[TimesLike, TimesLike]] = {
+        "pandas_series": (_PRED_PD, _EVAL_PD),
+        "datetimeindex": (pd.DatetimeIndex(_PRED_PD), pd.DatetimeIndex(_EVAL_PD)),
+        "numpy_datetime64": (_PRED_PD.to_numpy(), _EVAL_PD.to_numpy()),
+        "python_list": (list(_PRED_PD), list(_EVAL_PD)),
+    }
+    try:
+        import polars as pl
+
+        variants["polars_series"] = (pl.Series(_PRED_PD), pl.Series(_EVAL_PD))
+    except ImportError:
+        pass
+    return variants
+
+
+VARIANTS = _variants()
+
+
+@pytest.mark.parametrize("name", list(VARIANTS))
+def test_purge_equivalent_across_inputs(name: str) -> None:
+    pred, evalu = VARIANTS[name]
+    # purge()'s purge_horizon param is pd.Timedelta | None (never widened to the
+    # HorizonLike string-parsing accepted by the splitters/diagnostics), so a
+    # concrete Timedelta is used here rather than "1D".
+    baseline = purge(_TRAIN, _TEST, _PRED_PD, _EVAL_PD, purge_horizon=pd.Timedelta(days=1))
+    result = purge(_TRAIN, _TEST, pred, evalu, purge_horizon=pd.Timedelta(days=1))
+    np.testing.assert_array_equal(result, baseline)
+
+
+@pytest.mark.parametrize("name", list(VARIANTS))
+def test_apply_embargo_equivalent_across_inputs(name: str) -> None:
+    pred, evalu = VARIANTS[name]
+    baseline = apply_embargo(_TRAIN, _TEST, _PRED_PD, _EVAL_PD, pd.Timedelta(days=2))
+    result = apply_embargo(_TRAIN, _TEST, pred, evalu, pd.Timedelta(days=2))
+    np.testing.assert_array_equal(result, baseline)
+
+
+@pytest.mark.parametrize("name", list(VARIANTS))
+def test_overlap_fraction_equivalent_across_inputs(name: str) -> None:
+    pred, evalu = VARIANTS[name]
+    baseline = compute_overlap_fraction(_TRAIN, _TEST, _PRED_PD, _EVAL_PD)
+    result = compute_overlap_fraction(_TRAIN, _TEST, pred, evalu)
+    assert result == baseline
+
+
+@pytest.mark.parametrize("name", list(VARIANTS))
+def test_split_equivalent_across_inputs(name: str) -> None:
+    pred, evalu = VARIANTS[name]
+    X: NDArrayAny = np.zeros((N, 1))  # noqa: N806
+    base = list(
+        PurgedKFold(n_splits=4, prediction_times=_PRED_PD, evaluation_times=_EVAL_PD).split(X)
+    )
+    got = list(PurgedKFold(n_splits=4, prediction_times=pred, evaluation_times=evalu).split(X))
+    assert len(got) == len(base)
+    for (tr_b, te_b), (tr_g, te_g) in zip(base, got, strict=True):
+        np.testing.assert_array_equal(tr_g, tr_b)
+        np.testing.assert_array_equal(te_g, te_b)
+
+
+def test_timedelta64_family_supported() -> None:
+    # A timedelta-family dataset (offsets from an epoch) is also accepted.
+    pred_td = np.arange(N, dtype="timedelta64[D]")
+    evalu_td = pred_td + np.timedelta64(2, "D")
+    f = compute_overlap_fraction(_TRAIN, _TEST, pred_td, evalu_td)
+    assert 0.0 <= f <= 1.0


### PR DESCRIPTION
## What changes

Time inputs across the public API become framework-agnostic. Until now
`prediction_times`, `evaluation_times`, and `groups` had to be pandas
`Series`, and the hot path leaned on `.iloc`, `.reset_index`, `.isna`, and
`.is_monotonic_increasing`. This adds a single boundary coercion, `_coerce_1d`,
that turns any accepted input into a 1-D NumPy array, and moves the core to
NumPy. Every splitter constructor, together with `purge`, `apply_embargo`,
`validate_times`, and the `diagnostics` functions, now accepts pandas
`Series`/`DatetimeIndex`, NumPy `datetime64`/`timedelta64` arrays, Python lists
of datetime/Timestamp/timedelta values, and polars `Series`.

pandas stays a runtime dependency. polars is duck-typed through `.to_numpy()`
and never imported, so it adds nothing to the install; a polars user just
passes their own Series. tz-aware pandas input is normalized to UTC. The pandas
input path is byte-identical to before; public signatures only widen, to a new
`TimesLike` alias.


## Checklist

- [x] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [x] `mypy src tests` is clean.
- [x] `pytest -q` is green locally. (516 tests pass; the wall time is dominated
      by the pre-existing LCL-benchmark e2e tests, not by this change.)
- [x] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
      (`tests/e2e/test_e2e_framework_agnostic_times.py`: a numpy-only subprocess
      split and a polars-DataFrame CPCV user story.)
- [x] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
      (N/A: the only doc touched, `docs/installation.md`, is not a TARGET.)
- [x] If the docs site is affected, `mkdocs build --strict` is clean.
- [x] `CHANGELOG.md` has an entry under `Unreleased`, if the change is