### PR TITLE
feat: add support for multiple embargo modes in apply_embargo function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Plan is listed under the published version it shipped in.
 
 ### Added
 
+- Embargo can now be expressed in three mutually exclusive ways throughout
+  the splitter, PBO, row-level, and diagnostics APIs: a wall-clock duration
+  (`embargo`), a fixed number of post-test rows (`embargo_observations`), or a
+  fraction of the full dataset (`embargo_fraction`). Fractional embargo uses
+  `floor(n_samples * embargo_fraction)` observations. Positional modes apply
+  independently after every contiguous test block, including non-adjacent
+  CPCV groups, and preserve the established duration-based behavior.
+
+## [0.1.3] - 2026-08-01
+
+### Added
+
 - Time inputs are now framework-agnostic. `prediction_times` and
   `evaluation_times` on every splitter, together with `purge`, `apply_embargo`,
   `validate_times`, and the `diagnostics` functions, accept pandas
@@ -320,7 +332,8 @@ Development patch release.
 
 First PyPI release.
 
-[Unreleased]: https://github.com/eslazarev/purged-cross-validation/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/eslazarev/purged-cross-validation/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/eslazarev/purged-cross-validation/releases/tag/v0.1.3
 [0.1.2]: https://github.com/eslazarev/purged-cross-validation/releases/tag/v0.1.2
 [0.1.1]: https://github.com/eslazarev/purged-cross-validation/releases/tag/v0.1.1
 [0.1.0]: https://github.com/eslazarev/purged-cross-validation/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 | Symbol | Domain | Description |
 |---|---|---|
 | `purge` | D2 | Remove overlapping-horizon training rows |
-| `apply_embargo` | D3 | Remove post-test buffer rows |
+| `apply_embargo` | D3 | Remove time-, row-, or fraction-based post-test buffers |
 | `WalkForwardSplit` | D5.1 | Sliding / expanding walk-forward CV |
 | `PurgedKFold` | D5.2 | Contiguous test folds with purge + embargo |
 | `PurgedGroupKFold` | D5.3 | Group-aware purged k-fold |
@@ -148,6 +148,11 @@ mamba install -c conda-forge purgedcv
 pip install git+https://github.com/eslazarev/purged-cross-validation.git
 ```
 
+Time inputs are framework-agnostic: pandas `Series`/`DatetimeIndex`, NumPy
+`datetime64`/`timedelta64` arrays, Python datetime sequences, and Polars
+`Series` are accepted. Polars remains optional; inputs are converted to a
+one-dimensional NumPy array at the API boundary.
+
 ---
 
 ## Quickstart
@@ -215,11 +220,28 @@ Each bar below is one row's label horizon. Every training row whose start falls 
 
 ![apply_embargo on a mid-series test block: training rows whose prediction time falls inside the post-test buffer are dropped, while rows before the test are kept.](https://raw.githubusercontent.com/eslazarev/purged-cross-validation/main/.github/images/embargo_example.png)
 
+The buffer can use exactly one of three units:
+
+| Parameter | Meaning |
+|---|---|
+| `embargo="3D"` | Drop rows inside the three-day window after each test block |
+| `embargo_observations=10` | Drop the next 10 row positions after each test block |
+| `embargo_fraction=0.01` | Drop the next `floor(n_samples * 0.01)` row positions |
+
+Observation and fractional modes are useful for bar-based datasets where
+"the next 10 bars" is more stable than a wall-clock duration. For CPCV, each
+non-adjacent test block gets its own local embargo window. Supplying more than
+one mode raises `ValueError` rather than silently choosing one.
+
+`WalkForwardSplit` accepts these options for API consistency, but its train
+rows are strictly before each test fold, so a post-test embargo is a no-op;
+use `purge_horizon` for its pre-test boundary.
+
 ---
 
 ### 3. Walk-forward CV: `WalkForwardSplit`
 
-`WalkForwardSplit` walks the train/test split forward in time: every fold trains only on data *before* its test block, the way a model is actually deployed. Purge and embargo are applied automatically on each fold. Use `window="expanding"` to keep all history, or `window="sliding"` to cap training at a fixed-size recent window.
+`WalkForwardSplit` walks the train/test split forward in time: every fold trains only on data *before* its test block, the way a model is actually deployed. Purge is applied automatically on each fold; an asymmetric post-test embargo has no rows to remove in this layout. Use `window="expanding"` to keep all history, or `window="sliding"` to cap training at a fixed-size recent window.
 
 ```python
 import numpy as np
@@ -287,6 +309,9 @@ for i, (train_idx, test_idx) in enumerate(cv.split(X), 1):
 # fold 3: test 12..17  train rows 11
 # fold 4: test 18..23  train rows 15
 ```
+
+For a bar-count policy, replace `embargo="2D"` with either
+`embargo_observations=2` or, for example, `embargo_fraction=0.01`.
 
 Each test fold is a contiguous block. A middle fold trains on data both before and after it; the red purge gap before the test and the orange purge + embargo buffer after it are removed automatically, so no training row leaks into the fold.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 All public symbols from `purgedcv.__all__`, auto-rendered from the source
 docstrings. The constructors of the splitters share a single set of
 keyword arguments (`prediction_times`, `evaluation_times`,
-`purge_horizon`, `embargo`, `groups`); see
+`purge_horizon`, the three embargo modes, and `groups`); see
 [`BaseTemporalSplitter`](#purgedcv.BaseTemporalSplitter) for the shared
 contract.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,16 +51,17 @@ flowchart TB
 
 Three small invariants keep the surface honest.
 
-1. **One interval implementation.** All overlap and embargo checks go
-   through `src/purgedcv/_intervals.py`. `purge`, `apply_embargo`, and the
-   diagnostics all sort and merge per-test-row intervals once and then
-   stab them with `searchsorted`. Splitters do not duplicate boundary
-   logic, and a CPCV fold with non-adjacent test groups is filtered by
-   the *union* of local windows rather than by the convex hull between
-   them.
+1. **One implementation per boundary kind.** Time-based overlap and embargo
+   checks go through `src/purgedcv/_intervals.py`; positional embargo windows
+   are implemented once in `src/purgedcv/_embargo.py`. Splitters do not
+   duplicate either boundary rule. A CPCV fold with non-adjacent test groups
+   is filtered by the *union* of local windows rather than by the convex hull
+   between them.
 
-2. **Label-aware purge.** Splitters take `prediction_times` and
-   `evaluation_times` as pandas Series rather than a single integer gap.
+2. **Label-aware purge.** Splitters take framework-agnostic
+   `prediction_times` and `evaluation_times` containers rather than a single
+   integer gap. pandas, NumPy, Python sequences, and Polars are accepted and
+   coerced to one-dimensional NumPy arrays at the public boundary.
    The purge follows the real label horizon, so a label that overlaps by
    twelve half-hours and one that overlaps by twenty cannot share a
    single hand-tuned `gap` and still be correct — the user passes the

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,8 +1,9 @@
 # Examples
 
-The repository ships a controlled proof and ten worked notebooks on real
-public data. The point is to show the honest range of outcomes, including
-the undramatic ones, not only the alarming cases.
+The repository ships fifteen worked notebooks: controlled synthetic studies,
+real public datasets, model-selection regret experiments, and a full backtest
+overfitting audit. The point is to show the honest range of outcomes,
+including the undramatic ones, not only the alarming cases.
 
 The notebooks live in
 [`examples/`](https://github.com/eslazarev/purged-cross-validation/tree/main/examples)
@@ -20,6 +21,12 @@ shuffled k-fold scores R² between 0.83 and 0.91 on noise; `PurgedKFold`
 drives the train/test label overlap from 100 % to 0 % and the score
 collapses below a predict-the-mean baseline. Deterministic, fixed seed,
 no network.
+
+[**cv-leakage-controlled-study**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/cv-leakage-controlled-study.ipynb)
+— the same known-zero-skill construction repeated across 30 independent
+realisations. It compares shuffled and unshuffled KFold, walk-forward, and
+purged k-fold; only the shuffled split reports positive RandomForest skill.
+Deterministic and self-contained.
 
 ## Real datasets — dramatic leak
 
@@ -53,16 +60,33 @@ household: scoring on unseen customers is 6.03 % worse than the pooled
 temporal estimate (95 % CI 4.93 – 7.12 %). Which split you need follows
 from what you intend to deploy on.
 
+[**selection_regret_lcl**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/selection_regret_lcl.ipynb)
+— LCL model selection on 48 households followed by deployment to 12 unseen
+households. Naive shuffled KFold chooses a deep RandomForest that memorises
+household identity; `PurgedGroupKFold` chooses a regularised Ridge that
+deploys at lower MAE.
+
 [**model_comparison_honest_cv**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/model_comparison_honest_cv.ipynb)
 — same BTC data, six candidate models. Once the Deflated Sharpe Ratio
 corrects for the number of trials, no model clears DSR ≥ 0.95. Reporting
 no edge is the correct outcome.
+
+[**selection_regret_crypto**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/selection_regret_crypto.ipynb)
+— daily BTC/USDT model selection with a frozen 180-bar deployment window.
+Naive shuffled KFold selects a deep RandomForest that fails badly in the
+future; `PurgedKFold` selects a heavily regularised Ridge that stays near the
+honest no-edge baseline.
 
 [**epl_match_prediction**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/epl_match_prediction.ipynb)
 — Premier League sports modelling. The honest result is calibration drift
 across seasons rather than a headline accuracy gap.
 
 ## API-coverage examples
+
+[**backtest_overfitting_audit**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/backtest_overfitting_audit.ipynb)
+— a seeded Optuna search on BTC/USDT audited end to end with PBO,
+effective-trial DSR, CPCV backtest paths, and `path_metrics`. It distinguishes
+a real model-family effect from unreliable selection of one apparent champion.
 
 [**clinical_mortality_physionet**](https://github.com/eslazarev/purged-cross-validation/blob/main/examples/clinical_mortality_physionet.ipynb)
 — PhysioNet ICU mortality, `PurgedGroupKFold` holding whole patients out.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,9 @@ their neighbours, panel data has repeated customers, and a backtest
 needs more than a single train-then-test cut to be honest about its own
 overfitting. `purgedcv` is the scikit-learn-compatible answer to that.
 
-It ships purging and embargoing of overlapping labels, expanding and
-rolling walk-forward validation, purged and group-purged k-fold,
+It ships purging and time-, observation-, or fraction-based embargoing of
+overlapping labels, expanding and rolling walk-forward validation, purged and
+group-purged k-fold,
 Combinatorial Purged Cross-Validation with backtest-path reconstruction,
 and the Probabilistic, Deflated, and Minimum-Track-Record Sharpe
 statistics. Every splitter speaks the standard sklearn splitter protocol.
@@ -16,14 +17,14 @@ It drops straight into `cross_val_score`, `GridSearchCV`, and `Pipeline`.
 The algorithms are not new. They are Marcos López de Prado's (2018), with
 the statistical metrics from Bailey and López de Prado (2012, 2014). This
 library is an open, MIT-licensed, typed implementation, checked against
-the original papers and pinned by 354 tests (98% line coverage).
+the original papers and pinned by more than 500 tests.
 
 ## Where to start
 
 - [Installation](installation.md) — `pip install purgedcv` or `conda install -c conda-forge purgedcv`, optional extras.
 - [Quickstart](quickstart.md) — three short runnable snippets.
 - [API reference](api.md) — autodoc for every public symbol.
-- [Examples](examples.md) — eleven worked notebooks on real public data.
+- [Examples](examples.md) — fifteen worked notebooks on real public data.
 - [Methodology](methodology.md) — the underlying problem and the prior-art gap.
 - [Paper (JOSS)](https://github.com/eslazarev/purged-cross-validation/blob/main/paper/paper.md) — the software paper.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ Each extra is independent; install only what you need.
 
 === "Examples"
 
-    To run the eleven worked notebooks in `examples/` (Jupyter,
+    To run the fifteen worked notebooks in `examples/` (Jupyter,
     Matplotlib, the `pricehub` OHLC fetcher for the crypto examples):
 
     ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,6 +40,32 @@ train_kept = apply_embargo(
 print(len(train_idx), "->", len(train_kept), "after purge + embargo")
 ```
 
+### Choosing an embargo unit
+
+Every splitter, `apply_embargo`, PBO, and `assert_embargo_respected` accepts
+the same three mutually exclusive modes:
+
+```python
+# Wall-clock duration
+apply_embargo(train_idx, test_idx, pred, evalu, embargo="2D")
+
+# Fixed number of rows after each contiguous test block
+apply_embargo(train_idx, test_idx, pred, evalu, embargo_observations=10)
+
+# floor(n_samples * 0.01) rows after each contiguous test block
+apply_embargo(train_idx, test_idx, pred, evalu, embargo_fraction=0.01)
+```
+
+Use a duration when elapsed time carries the dependency. Use rows or a
+fraction for bar-based data where serial dependence is naturally expressed in
+observations. CPCV applies the positional window separately after every
+non-adjacent test block. Supplying more than one mode raises `ValueError`.
+
+`WalkForwardSplit` accepts the same parameters for constructor consistency,
+but its training candidates are always strictly before the test fold, so an
+asymmetric post-test embargo has no rows to remove. Its effective boundary
+control is `purge_horizon`.
+
 ## 2. PurgedKFold in `cross_val_score`
 
 Every splitter follows the scikit-learn splitter protocol, so it works

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,12 @@ pip install purgedcv[examples]
 jupyter notebook examples/
 ```
 
+All splitter examples continue to use pandas timestamps, but the same APIs
+also accept NumPy datetime arrays, Python datetime sequences, and Polars
+`Series`. Time-based examples use `embargo="..."`; bar-based workflows can
+instead use `embargo_observations=...` or `embargo_fraction=...` (never more
+than one mode at once).
+
 ---
 
 ## Controlled proof (no download, deterministic)
@@ -27,6 +33,26 @@ and `PurgedKFold` run side by side. Naive scores R² ≈ 0.83–0.91 on a target
 nothing can predict; `PurgedKFold` drops the train/test label overlap from 100%
 to 0% and that fabricated skill collapses below a predict-the-mean baseline.
 Deterministic (fixed seed) and offline — no download.
+
+`cv-leakage-controlled-study.ipynb` expands the same known-zero-skill setup to
+30 independent realisations and compares four splitters: shuffled and
+unshuffled KFold, `WalkForwardSplit`, and `PurgedKFold`. Only shuffled KFold
+reports positive RandomForest skill. It is also deterministic and requires no
+download.
+
+## Selection-regret studies
+
+`selection_regret_lcl.ipynb` selects models on 48 Low Carbon London households
+and deploys them to 12 unseen households. Naive shuffled KFold chooses a model
+that memorises household identity; `PurgedGroupKFold` chooses a regularised
+model that deploys at lower MAE. It uses the same cached LCL dataset described
+below.
+
+`selection_regret_crypto.ipynb` repeats the selection/deployment protocol on
+daily BTC/USDT. Naive KFold chooses a deep RandomForest that fails on a frozen
+180-bar future window; `PurgedKFold` chooses a strongly regularised Ridge that
+correctly stays near the no-edge baseline. It shares the cached crypto data
+used by the OHLC examples below.
 
 ---
 

--- a/src/purgedcv/_base.py
+++ b/src/purgedcv/_base.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator, Sequence
 import numpy as np
 import pandas as pd
 
-from purgedcv._embargo import apply_embargo
+from purgedcv._embargo import _validate_embargo_modes, apply_embargo
 from purgedcv._purge import purge
 from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
 from purgedcv._validation import _validate_positional_indices
@@ -32,8 +32,9 @@ class BaseTemporalSplitter(ABC):
 
     .. note::
        The subclassing interface (``_iter_test_indices``,
-       ``_candidate_train_idx``) is not yet covered by the v0.3 stability
-       contract. Subclasses may need adjustments through v1.0.
+       ``_candidate_train_idx``) is an implementation detail, not part of the
+       maintained ``0.1.x`` public contract. Subclasses may need adjustments
+       before v1.0.
     """
 
     def __init__(
@@ -43,6 +44,8 @@ class BaseTemporalSplitter(ABC):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
         groups: ArrayLike1D | None = None,
     ) -> None:
         pred = _coerce_1d(prediction_times, name="prediction_times")
@@ -53,7 +56,12 @@ class BaseTemporalSplitter(ABC):
         self.purge_horizon = (
             parse_horizon(purge_horizon) if purge_horizon is not None else pd.Timedelta(0)
         )
-        self.embargo = parse_horizon(embargo) if embargo is not None else pd.Timedelta(0)
+        duration, observations, fraction = _validate_embargo_modes(
+            embargo, embargo_observations, embargo_fraction
+        )
+        self.embargo = duration if duration is not None else pd.Timedelta(0)
+        self.embargo_observations = observations
+        self.embargo_fraction = fraction
         self._groups: NDArrayAny | None
         if groups is not None:
             groups_arr = _coerce_1d(groups, name="groups")
@@ -75,7 +83,10 @@ class BaseTemporalSplitter(ABC):
 
     @abstractmethod
     def get_n_splits(
-        self, X: object = None, y: object = None, groups: object = None  # noqa: N803
+        self,
+        X: object = None,  # noqa: N803
+        y: object = None,
+        groups: object = None,
     ) -> int:
         """Return the total number of splits the iterator will yield."""
         ...
@@ -115,7 +126,13 @@ class BaseTemporalSplitter(ABC):
                 test_idx,
                 self._prediction_times,
                 self._evaluation_times,
-                embargo=self.embargo,
+                embargo=(
+                    self.embargo
+                    if self.embargo_observations is None and self.embargo_fraction is None
+                    else None
+                ),
+                embargo_observations=self.embargo_observations,
+                embargo_fraction=self.embargo_fraction,
             )
             if self._groups is not None:
                 assert_groups_disjoint(train_idx, test_idx, self._groups)
@@ -143,8 +160,8 @@ class BaseTemporalSplitter(ABC):
         evaluation_times: TimesLike,
     ) -> BaseTemporalSplitter:
         """Return a copy of this splitter with new times bound. All other
-        parameters (``n_splits``, ``purge_horizon``, ``embargo``, ``groups``,
-        and any subclass-specific state such as a cached unique-group list)
+        parameters (``n_splits``, ``purge_horizon``, every embargo mode,
+        ``groups``, and any subclass-specific state such as a cached unique-group list)
         are preserved unchanged.
 
         To change ``groups`` or any other construction parameter, build a

--- a/src/purgedcv/_cpcv.py
+++ b/src/purgedcv/_cpcv.py
@@ -64,6 +64,8 @@ class CombinatorialPurgedCV(BaseTemporalSplitter):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
     ) -> None:
         """Configure a Combinatorial Purged CV splitter.
 
@@ -83,6 +85,12 @@ class CombinatorialPurgedCV(BaseTemporalSplitter):
                 ``[test_evaluation_time, test_evaluation_time + embargo]``
                 are dropped.
                 ``None`` means no embargo.
+            embargo_observations: Number of row positions to embargo after
+                each contiguous test block. Mutually exclusive with
+                ``embargo`` and ``embargo_fraction``.
+            embargo_fraction: Fraction of the full dataset to embargo after
+                each contiguous test block, rounded down. Mutually exclusive
+                with the other modes.
 
         Raises:
             ValueError: if ``n_splits < 2``, if ``n_splits`` exceeds the
@@ -101,6 +109,8 @@ class CombinatorialPurgedCV(BaseTemporalSplitter):
             evaluation_times=evaluation_times,
             purge_horizon=purge_horizon,
             embargo=embargo,
+            embargo_observations=embargo_observations,
+            embargo_fraction=embargo_fraction,
         )
         if n_splits > len(self._prediction_times):
             raise ValueError(
@@ -319,6 +329,8 @@ class CombinatoriallySymmetricCV(CombinatorialPurgedCV):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
     ) -> None:
         """Configure a CSCV splitter.
 
@@ -330,6 +342,10 @@ class CombinatoriallySymmetricCV(CombinatorialPurgedCV):
             evaluation_times: Per-sample evaluation times.
             purge_horizon: Optional purge horizon applied per fold.
             embargo: Optional embargo horizon applied per fold.
+            embargo_observations: Optional number of post-test row positions
+                embargoed per contiguous block.
+            embargo_fraction: Optional fraction of the dataset embargoed as
+                row positions per contiguous block.
 
         Raises:
             ValueError: if ``n_splits`` is odd or below 2.
@@ -344,4 +360,6 @@ class CombinatoriallySymmetricCV(CombinatorialPurgedCV):
             evaluation_times=evaluation_times,
             purge_horizon=purge_horizon,
             embargo=embargo,
+            embargo_observations=embargo_observations,
+            embargo_fraction=embargo_fraction,
         )

--- a/src/purgedcv/_embargo.py
+++ b/src/purgedcv/_embargo.py
@@ -10,10 +10,65 @@ import numpy as np
 import pandas as pd
 
 from purgedcv._intervals import points_in_any_closed_interval
-from purgedcv._time import _coerce_1d, validate_times
-from purgedcv._validation import _validate_positional_indices
+from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
+from purgedcv._validation import _validate_integer, _validate_positional_indices
 
 from ._typing import NDArrayAny, TimesLike
+
+
+def _validate_embargo_modes(
+    embargo: HorizonLike | None,
+    embargo_observations: int | None,
+    embargo_fraction: float | None,
+) -> tuple[pd.Timedelta | None, int | None, float | None]:
+    """Validate the three mutually-exclusive embargo modes."""
+    supplied = sum(value is not None for value in (embargo, embargo_observations, embargo_fraction))
+    if supplied > 1:
+        raise ValueError(
+            "embargo, embargo_observations, and embargo_fraction are mutually exclusive; "
+            "supply at most one."
+        )
+
+    if embargo is not None:
+        missing = pd.isna(embargo)
+        if isinstance(missing, (bool, np.bool_)) and bool(missing):
+            raise ValueError("embargo must be non-missing, got NaT.")
+    duration = parse_horizon(embargo) if embargo is not None else None
+    observations = (
+        _validate_integer("embargo_observations", embargo_observations, minimum=0)
+        if embargo_observations is not None
+        else None
+    )
+    fraction: float | None = None
+    if embargo_fraction is not None:
+        if isinstance(embargo_fraction, bool) or not isinstance(
+            embargo_fraction, (int, float, np.integer, np.floating)
+        ):
+            raise TypeError(
+                "embargo_fraction must be a real number in [0, 1], got "
+                f"{type(embargo_fraction).__name__}."
+            )
+        fraction = float(embargo_fraction)
+        if not np.isfinite(fraction) or not 0.0 <= fraction <= 1.0:
+            raise ValueError(f"embargo_fraction must be in [0, 1], got {embargo_fraction}.")
+    return duration, observations, fraction
+
+
+def _positional_embargo_mask(
+    train_idx: NDArrayAny,
+    test_idx: NDArrayAny,
+    embargo_observations: int,
+) -> NDArrayAny:
+    """Return a mask for train rows in the post-test positional windows."""
+    if embargo_observations == 0 or len(train_idx) == 0 or len(test_idx) == 0:
+        return np.zeros(len(train_idx), dtype=bool)
+
+    sorted_test = np.sort(test_idx)
+    run_ends = sorted_test[np.r_[np.diff(sorted_test) > 1, True]]
+    in_embargo = np.zeros(len(train_idx), dtype=bool)
+    for run_end in run_ends:
+        in_embargo |= (train_idx > run_end) & (train_idx <= int(run_end) + embargo_observations)
+    return in_embargo
 
 
 def apply_embargo(
@@ -21,15 +76,26 @@ def apply_embargo(
     test_idx: NDArrayAny,
     prediction_times: TimesLike,
     evaluation_times: TimesLike,
-    embargo: pd.Timedelta,
+    embargo: HorizonLike | None = None,
+    *,
+    embargo_observations: int | None = None,
+    embargo_fraction: float | None = None,
 ) -> NDArrayAny:
-    """Drop training rows whose ``prediction_time`` falls inside any closed
-    embargo window ``[test_evaluation_time, test_evaluation_time + embargo]``.
+    """Drop training rows inside a post-test embargo window.
 
-    Embargo is asymmetric: rows whose ``prediction_time`` is strictly before
-    all test evaluation times are never dropped. ``embargo == 0`` is the
-    identity (the embargo window is logically empty at zero width), avoiding
-    degenerate single-point windows.
+    Choose at most one embargo mode:
+
+    - ``embargo`` uses a wall-clock duration and drops rows whose
+      ``prediction_time`` falls inside any closed window
+      ``[test_evaluation_time, test_evaluation_time + embargo]``;
+    - ``embargo_observations`` drops that many row positions immediately
+      after each contiguous test block;
+    - ``embargo_fraction`` drops ``floor(n_samples * fraction)`` row positions
+      after each contiguous test block.
+
+    Embargo is asymmetric: only rows after a test boundary are dropped.
+    ``embargo == 0``, ``embargo_observations == 0``, and a fractional mode
+    that rounds to zero are identities.
 
     Args:
         train_idx: positional indices of training rows.
@@ -37,10 +103,15 @@ def apply_embargo(
         prediction_times: prediction times for all rows.
         evaluation_times: evaluation times for all rows.
         embargo: post-test embargo duration.
+        embargo_observations: number of row positions to drop after each
+            contiguous test block.
+        embargo_fraction: fraction of the full dataset to drop after each
+            contiguous test block. Must be between 0 and 1 inclusive; the
+            observation count is rounded down.
 
     Returns:
-        The subset of ``train_idx`` whose prediction_times fall outside the
-        post-test embargo window. Input ordering and dtype are preserved.
+        The subset of ``train_idx`` outside the post-test embargo windows.
+        Input ordering and dtype are preserved.
 
     Examples:
         >>> import numpy as np
@@ -53,10 +124,9 @@ def apply_embargo(
         >>> apply_embargo(train_idx, test_idx, pred, evalu, pd.Timedelta(days=1))
         array([12, 13, 14])
     """
-    if pd.isna(embargo):
-        raise ValueError("embargo must be non-missing, got NaT.")
-    if embargo < pd.Timedelta(0):
-        raise ValueError(f"embargo must be non-negative, got {embargo}.")
+    duration, observations, fraction = _validate_embargo_modes(
+        embargo, embargo_observations, embargo_fraction
+    )
     prediction_times = _coerce_1d(prediction_times, name="prediction_times")
     evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
@@ -65,12 +135,24 @@ def apply_embargo(
     test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=n_samples)
     if len(train_idx) == 0 or len(test_idx) == 0:
         return np.asarray(train_idx)
-    if embargo == pd.Timedelta(0):
+    if duration is None and observations is None and fraction is None:
         return np.asarray(train_idx)
+
+    if fraction is not None:
+        observations = int(n_samples * fraction)
+    if observations is not None:
+        in_embargo = _positional_embargo_mask(train_idx, test_idx, observations)
+        kept: NDArrayAny = train_idx[~in_embargo]
+        return kept
+
+    if duration == pd.Timedelta(0):
+        return np.asarray(train_idx)
+    if duration is None:  # pragma: no cover - exhaustive mode validation above
+        raise RuntimeError("embargo mode was not resolved")
 
     train_pred = prediction_times[train_idx]
     embargo_starts = evaluation_times[test_idx]
-    embargo_ends = evaluation_times[test_idx] + embargo
+    embargo_ends = evaluation_times[test_idx] + duration
     in_embargo = points_in_any_closed_interval(train_pred, embargo_starts, embargo_ends)
-    kept: NDArrayAny = train_idx[~in_embargo]
-    return kept
+    kept_by_time: NDArrayAny = train_idx[~in_embargo]
+    return kept_by_time

--- a/src/purgedcv/_pbo.py
+++ b/src/purgedcv/_pbo.py
@@ -125,6 +125,8 @@ def _iter_is_oos(
     evaluation_times: TimesLike | None,
     purge_horizon: HorizonLike | None,
     embargo: HorizonLike | None,
+    embargo_observations: int | None,
+    embargo_fraction: float | None,
 ) -> Iterator[tuple[NDArrayAny, NDArrayAny]]:
     """Yield ``(is_idx, oos_idx)`` for every CSCV combination.
 
@@ -134,7 +136,15 @@ def _iter_is_oos(
     the IS/OOS boundaries.
     """
     n_test_groups = n_splits // 2
-    wants_purge = purge_horizon is not None or embargo is not None
+    wants_purge = any(
+        value is not None
+        for value in (
+            purge_horizon,
+            embargo,
+            embargo_observations,
+            embargo_fraction,
+        )
+    )
     if prediction_times is None and evaluation_times is None and not wants_purge:
         blocks = _contiguous_blocks(n_obs, n_splits)
         for oos_combo in combinations(range(n_splits), n_test_groups):
@@ -149,7 +159,7 @@ def _iter_is_oos(
     if prediction_times is None or evaluation_times is None:
         raise ValueError(
             "prediction_times and evaluation_times must be supplied together "
-            "(or both omitted); purge_horizon and embargo require both."
+            "(or both omitted); purge_horizon and every embargo mode require both."
         )
     cv = CombinatorialPurgedCV(
         n_splits=n_splits,
@@ -158,6 +168,8 @@ def _iter_is_oos(
         evaluation_times=evaluation_times,
         purge_horizon=purge_horizon,
         embargo=embargo,
+        embargo_observations=embargo_observations,
+        embargo_fraction=embargo_fraction,
     )
     placeholder = np.empty((n_obs, 1), dtype=float)
     yield from cv.split(placeholder)
@@ -266,6 +278,8 @@ def probability_of_backtest_overfitting(
     evaluation_times: TimesLike | None = None,
     purge_horizon: HorizonLike | None = None,
     embargo: HorizonLike | None = None,
+    embargo_observations: int | None = None,
+    embargo_fraction: float | None = None,
 ) -> PBOResult:
     """Estimate the Probability of Backtest Overfitting (PBO) via CSCV.
 
@@ -292,6 +306,10 @@ def probability_of_backtest_overfitting(
             ``prediction_times``.
         purge_horizon: Optional purge horizon (requires the time series).
         embargo: Optional embargo horizon (requires the time series).
+        embargo_observations: Optional number of row positions to embargo
+            after each OOS block (requires the time series).
+        embargo_fraction: Optional fraction of rows to embargo after each
+            OOS block (requires the time series).
 
     Returns:
         A :class:`PBOResult` (frozen dataclass; read fields by attribute,
@@ -334,7 +352,16 @@ def probability_of_backtest_overfitting(
     is_perf_best: list[float] = []
     oos_perf_best: list[float] = []
     n_dropped = 0
-    for is_idx, oos_idx in _iter_is_oos(n_obs, n_splits, pred, evalu, purge_horizon, embargo):
+    for is_idx, oos_idx in _iter_is_oos(
+        n_obs,
+        n_splits,
+        pred,
+        evalu,
+        purge_horizon,
+        embargo,
+        embargo_observations,
+        embargo_fraction,
+    ):
         if len(is_idx) == 0 or len(oos_idx) == 0:
             n_dropped += 1
             continue

--- a/src/purgedcv/_purged_kfold.py
+++ b/src/purgedcv/_purged_kfold.py
@@ -62,6 +62,8 @@ class PurgedKFold(BaseTemporalSplitter):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
     ) -> None:
         """Configure a purged k-fold splitter.
 
@@ -78,6 +80,12 @@ class PurgedKFold(BaseTemporalSplitter):
                 ``[test_evaluation_time, test_evaluation_time + embargo]``
                 are dropped.
                 ``None`` means no embargo.
+            embargo_observations: Number of row positions to embargo after
+                each test block. Mutually exclusive with ``embargo`` and
+                ``embargo_fraction``.
+            embargo_fraction: Fraction of the full dataset to embargo after
+                each test block, rounded down to a row count. Must be in
+                ``[0, 1]`` and is mutually exclusive with the other modes.
 
         Raises:
             ValueError: if ``n_splits < 2``.
@@ -88,6 +96,8 @@ class PurgedKFold(BaseTemporalSplitter):
             evaluation_times=evaluation_times,
             purge_horizon=purge_horizon,
             embargo=embargo,
+            embargo_observations=embargo_observations,
+            embargo_fraction=embargo_fraction,
         )
         self.n_splits = n_splits
 
@@ -127,6 +137,12 @@ class PurgedGroupKFold(BaseTemporalSplitter):
     assets in time-of-IPO order — ensure the ``groups`` Series is sorted
     by first occurrence time.
 
+    Observation-count and fractional embargo operate on row positions, not
+    group identities. They apply after every contiguous run of test positions.
+    If a fold's groups are interleaved through the dataset, that fold contains
+    several short test runs and positional embargo can remove substantially
+    more rows than a single fold-level buffer would.
+
     The base class's :func:`assert_groups_disjoint` enforcement runs on
     every fold automatically because ``groups`` is bound at construction.
 
@@ -159,6 +175,8 @@ class PurgedGroupKFold(BaseTemporalSplitter):
         groups: ArrayLike1D,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
     ) -> None:
         """Configure a group-aware purged k-fold splitter.
 
@@ -177,6 +195,14 @@ class PurgedGroupKFold(BaseTemporalSplitter):
                 ``None`` means no purge.
             embargo: Post-test embargo duration. ``None`` means no
                 embargo.
+            embargo_observations: Number of row positions to embargo after
+                each contiguous run of test positions. Interleaved test
+                groups may create many such runs. Mutually exclusive with
+                ``embargo`` and ``embargo_fraction``.
+            embargo_fraction: Fraction of the full dataset to embargo after
+                each contiguous run of test positions, rounded down.
+                Interleaved groups may create many runs. Mutually exclusive
+                with the other modes.
 
         Raises:
             ValueError: if ``n_splits < 2`` or
@@ -188,6 +214,8 @@ class PurgedGroupKFold(BaseTemporalSplitter):
             evaluation_times=evaluation_times,
             purge_horizon=purge_horizon,
             embargo=embargo,
+            embargo_observations=embargo_observations,
+            embargo_fraction=embargo_fraction,
             groups=groups,
         )
         if self._groups is None:  # bound at construction; should be unreachable

--- a/src/purgedcv/_walk_forward.py
+++ b/src/purgedcv/_walk_forward.py
@@ -25,6 +25,12 @@ class WalkForwardSplit(BaseTemporalSplitter):
     ``window="sliding"``, the training window has a fixed maximum length
     (the most recent ``train_size`` samples before the test fold).
 
+    Post-test embargo parameters are accepted for API consistency with the
+    other temporal splitters, but they cannot remove rows here: every
+    candidate training index is strictly before the test fold. Use
+    ``purge_horizon`` to remove pre-test rows whose label horizons overlap the
+    test boundary.
+
     Examples:
         >>> import numpy as np
         >>> import pandas as pd
@@ -50,6 +56,8 @@ class WalkForwardSplit(BaseTemporalSplitter):
         evaluation_times: TimesLike,
         purge_horizon: HorizonLike | None = None,
         embargo: HorizonLike | None = None,
+        embargo_observations: int | None = None,
+        embargo_fraction: float | None = None,
     ) -> None:
         """Configure a walk-forward CV splitter.
 
@@ -60,29 +68,32 @@ class WalkForwardSplit(BaseTemporalSplitter):
             test_size: Number of consecutive rows in each test fold.
                 ``n_splits * test_size`` must be strictly less than
                 ``n_samples``.
-            train_size: Maximum number of training rows per fold AFTER
-                purge and embargo. Counts kept rows, not raw indices, so
-                with a 2-day embargo and ``train_size=100`` the effective
-                training set may use indices spanning more than 100 rows.
+            train_size: Maximum number of training rows per fold after purge.
+                Counts kept rows, not raw indices, so with a purge gap and
+                ``train_size=100`` the effective training set may use indices
+                spanning more than 100 rows.
                 Must be ``None`` when ``window='expanding'`` and a positive
                 integer when ``window='sliding'``.
             window: ``"expanding"`` (default) uses all pre-test data as
                 training; matches :class:`sklearn.model_selection.TimeSeriesSplit`
-                when purge and embargo are zero. ``"sliding"`` caps each
-                training set at the most recent ``train_size`` rows after
-                purge and embargo.
+                when purge is zero. ``"sliding"`` caps each training set at
+                the most recent ``train_size`` rows after purge.
             prediction_times: Per-sample prediction times for the dataset.
                 Bound at construction so :meth:`split` matches the sklearn
                 signature.
-            evaluation_times: Per-sample evaluation times. Required to
-                apply purge and embargo correctly.
+            evaluation_times: Per-sample evaluation times. Required to apply
+                purge correctly.
             purge_horizon: Symmetric padding around the test fold's label
                 window; training rows whose label horizon overlaps the
                 padded test horizon are dropped. ``None`` means no purge.
-            embargo: Post-test embargo duration; training rows whose
-                prediction time falls in the closed window
-                ``[test_eval_max, test_eval_max + embargo]`` are dropped.
-                ``None`` means no embargo.
+            embargo: Accepted for consistency, but has no effect because
+                walk-forward training rows are all before the test fold.
+            embargo_observations: Accepted for consistency; also a no-op for
+                the strictly pre-test candidate training set. Mutually
+                exclusive with the other modes.
+            embargo_fraction: Accepted for consistency; also a no-op for the
+                strictly pre-test candidate training set. Mutually exclusive
+                with the other modes.
 
         Raises:
             ValueError: if ``window`` is not one of the literal values, if
@@ -95,6 +106,8 @@ class WalkForwardSplit(BaseTemporalSplitter):
             evaluation_times=evaluation_times,
             purge_horizon=purge_horizon,
             embargo=embargo,
+            embargo_observations=embargo_observations,
+            embargo_fraction=embargo_fraction,
         )
         if window not in ("sliding", "expanding"):
             raise ValueError(f"window must be 'sliding' or 'expanding', got {window!r}.")

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pandas as pd
 
+from purgedcv._embargo import _positional_embargo_mask, _validate_embargo_modes
 from purgedcv._intervals import overlaps_any_half_open_interval, points_in_any_closed_interval
 from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
 from purgedcv._validation import _validate_positional_indices
@@ -101,16 +102,20 @@ def assert_embargo_respected(
     test_idx: NDArrayAny,
     prediction_times: TimesLike,
     evaluation_times: TimesLike,
-    embargo: HorizonLike,
+    embargo: HorizonLike | None = None,
+    *,
+    embargo_observations: int | None = None,
+    embargo_fraction: float | None = None,
 ) -> None:
-    """Raise :class:`EmbargoViolationError` if any training row's
-    ``prediction_time`` falls inside any closed embargo window
-    ``[test_evaluation_time, test_evaluation_time + embargo]``.
+    """Raise :class:`EmbargoViolationError` when an embargo is violated.
 
-    Embargo is asymmetric: rows whose ``prediction_time`` is strictly before
-    all test evaluation times are never flagged. ``embargo == 0`` is the
-    identity (no rows flagged) — the embargo window is logically empty at
-    zero width.
+    The duration, observation-count, and fractional modes have the same
+    mutually-exclusive semantics as :func:`purgedcv.apply_embargo`. Exactly
+    one mode must be supplied; omitting all three is treated as a configuration
+    error rather than a successful audit.
+
+    Embargo is asymmetric: rows before test boundaries are never flagged.
+    Zero-width modes are identities.
 
     Examples:
         >>> import numpy as np
@@ -122,7 +127,14 @@ def assert_embargo_respected(
         ...     np.array([18]), np.arange(5, 10), pred, evalu, embargo="2D"
         ... )
     """
-    emb = parse_horizon(embargo)
+    duration, observations, fraction = _validate_embargo_modes(
+        embargo, embargo_observations, embargo_fraction
+    )
+    if duration is None and observations is None and fraction is None:
+        raise ValueError(
+            "assert_embargo_respected requires one of embargo, "
+            "embargo_observations, or embargo_fraction."
+        )
     prediction_times = _coerce_1d(prediction_times, name="prediction_times")
     evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
@@ -131,12 +143,26 @@ def assert_embargo_respected(
     test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=n_samples)
     if len(train_idx) == 0 or len(test_idx) == 0:
         return
-    if emb == pd.Timedelta(0):
+    if fraction is not None:
+        observations = int(n_samples * fraction)
+    if observations is not None:
+        in_embargo = _positional_embargo_mask(train_idx, test_idx, observations)
+        if in_embargo.any():
+            first_global = int(train_idx[int(in_embargo.argmax())])
+            raise EmbargoViolationError(
+                f"Embargo violation at row {first_global}: row position falls "
+                "inside a post-test positional embargo window."
+            )
         return
+
+    if duration == pd.Timedelta(0):
+        return
+    if duration is None:  # pragma: no cover - exhaustive mode validation above
+        raise RuntimeError("embargo mode was not resolved")
 
     train_pred = prediction_times[train_idx]
     embargo_starts = evaluation_times[test_idx]
-    embargo_ends = evaluation_times[test_idx] + emb
+    embargo_ends = evaluation_times[test_idx] + duration
     in_embargo = points_in_any_closed_interval(train_pred, embargo_starts, embargo_ends)
     if in_embargo.any():
         first_local = int(in_embargo.argmax())

--- a/tests/e2e/test_e2e_apply_embargo.py
+++ b/tests/e2e/test_e2e_apply_embargo.py
@@ -51,6 +51,33 @@ def test_user_story_zero_embargo_is_identity() -> None:
 
 
 @pytest.mark.e2e
+def test_user_story_fractional_embargo_then_diagnostic_clean() -> None:
+    """A bar-based strategy can use a 10% embargo without translating bars
+    into a wall-clock duration."""
+    pred = pd.Series(pd.date_range("2024-01-01", periods=30, freq="h"))
+    evalu = pred + pd.Timedelta(hours=1)
+    test_idx = np.arange(10, 15)
+    train_idx = np.concatenate([np.arange(0, 10), np.arange(15, 30)])
+
+    embargoed = apply_embargo(
+        train_idx,
+        test_idx,
+        pred,
+        evalu,
+        embargo_fraction=0.1,
+    )
+
+    assert {15, 16, 17}.isdisjoint(embargoed)
+    assert_embargo_respected(
+        embargoed,
+        test_idx,
+        pred,
+        evalu,
+        embargo_fraction=0.1,
+    )
+
+
+@pytest.mark.e2e
 def test_user_story_pre_test_history_preserved() -> None:
     """Asymmetry visible at API level: embargo never drops pre-test data."""
     pred = pd.Series(pd.date_range("2024-01-01", periods=30, freq="D"))

--- a/tests/e2e/test_e2e_assert_embargo_respected.py
+++ b/tests/e2e/test_e2e_assert_embargo_respected.py
@@ -60,6 +60,14 @@ def test_user_story_pre_test_history_never_flagged() -> None:
 
 
 @pytest.mark.e2e
+def test_user_story_missing_embargo_configuration_is_rejected() -> None:
+    pred = pd.Series(pd.date_range("2024-01-01", periods=20, freq="D"))
+    evalu = pred + pd.Timedelta(days=1)
+    with pytest.raises(ValueError, match="requires one of embargo"):
+        assert_embargo_respected(np.array([15]), np.arange(10, 15), pred, evalu)
+
+
+@pytest.mark.e2e
 def test_subprocess_fresh_interpreter_embargo() -> None:
     snippet = textwrap.dedent("""\
         import numpy as np

--- a/tests/test_base_splitter.py
+++ b/tests/test_base_splitter.py
@@ -26,7 +26,10 @@ class _TwoFoldStub(BaseTemporalSplitter):
         return [np.arange(mid), np.arange(mid, n_samples)]
 
     def get_n_splits(
-        self, X: object = None, y: object = None, groups: object = None  # noqa: N803
+        self,
+        X: object = None,  # noqa: N803
+        y: object = None,
+        groups: object = None,
     ) -> int:
         return 2
 
@@ -96,6 +99,29 @@ class TestBaseTemporalSplitterSkeleton:
         cv = _TwoFoldStub(prediction_times=pred, evaluation_times=evalu)
         assert cv.purge_horizon == pd.Timedelta(0)
         assert cv.embargo == pd.Timedelta(0)
+        assert cv.embargo_observations is None
+        assert cv.embargo_fraction is None
+
+    def test_constructor_stores_observation_embargo(self) -> None:
+        pred, evalu = _times()
+        cv = _TwoFoldStub(
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_observations=3,
+        )
+        assert cv.embargo == pd.Timedelta(0)
+        assert cv.embargo_observations == 3
+        assert cv.embargo_fraction is None
+
+    def test_constructor_rejects_multiple_embargo_modes(self) -> None:
+        pred, evalu = _times()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _TwoFoldStub(
+                prediction_times=pred,
+                evaluation_times=evalu,
+                embargo="1D",
+                embargo_fraction=0.1,
+            )
 
     def test_constructor_validates_times(self) -> None:
         """Mismatched-length times must be rejected at construction."""
@@ -249,6 +275,19 @@ class TestBaseTemporalSplitterSplit:
         assert set(test0.tolist()) == set(range(10))
         assert set(train0.tolist()) == set(range(13, 20))
 
+    def test_split_applies_observation_embargo(self) -> None:
+        pred, evalu = _times(n=20, horizon_days=1)
+        cv = _TwoFoldStub(
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_observations=3,
+        )
+
+        train0, test0 = next(cv.split(np.zeros((20, 1))))
+
+        np.testing.assert_array_equal(test0, np.arange(10))
+        np.testing.assert_array_equal(train0, np.arange(13, 20))
+
 
 class TestBaseTemporalSplitterWithTimes:
     def test_returns_new_instance_with_rebound_times(self) -> None:
@@ -266,6 +305,19 @@ class TestBaseTemporalSplitterWithTimes:
         # Other attributes preserved.
         assert cv2.purge_horizon == cv.purge_horizon
         assert cv2.embargo == cv.embargo
+
+    def test_preserves_positional_embargo_when_rebinding_times(self) -> None:
+        pred, evalu = _times(n=20)
+        cv = _TwoFoldStub(
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_fraction=0.1,
+        )
+        new_pred = pd.Series(pd.date_range("2025-01-01", periods=20, freq="D"))
+        cv2 = cv.with_times(new_pred, new_pred + pd.Timedelta(days=1))
+
+        assert cv2.embargo_observations is None
+        assert cv2.embargo_fraction == 0.1
 
     def test_rejects_length_mismatch(self) -> None:
         pred, evalu = _times(n=20)

--- a/tests/test_cpcv.py
+++ b/tests/test_cpcv.py
@@ -26,6 +26,28 @@ def _times(n: int = 24, horizon_days: int = 1) -> tuple[pd.Series, pd.Series]:
 
 
 class TestCombinatorialPurgedCV:
+    def test_observation_embargo_applies_after_each_non_adjacent_test_block(self) -> None:
+        pred, evalu = _times(n=16, horizon_days=1)
+        cv = CombinatorialPurgedCV(
+            n_splits=4,
+            n_test_groups=2,
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_observations=1,
+        )
+
+        fold_by_test = {
+            tuple(test_idx.tolist()): train_idx
+            for train_idx, test_idx in cv.split(np.zeros((16, 1)))
+        }
+        test_idx = tuple([*range(0, 4), *range(8, 12)])
+        train_idx = fold_by_test[test_idx]
+
+        assert 4 not in train_idx
+        assert 12 not in train_idx
+        assert 5 in train_idx
+        assert 13 in train_idx
+
     def test_yields_n_choose_k_folds(self) -> None:
         """For N=6 groups and K=2 test groups per fold, expect C(6,2)=15."""
         pred, evalu = _times(n=24)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -123,6 +123,11 @@ class TestAssertNoTemporalLeakage:
 
 
 class TestAssertEmbargoRespected:
+    def test_requires_an_embargo_mode(self) -> None:
+        pred, evalu = _make_horizon_dataset()
+        with pytest.raises(ValueError, match="requires one of embargo"):
+            assert_embargo_respected(np.array([15]), np.arange(10, 15), pred, evalu)
+
     def test_zero_embargo_is_identity(self) -> None:
         """embargo=0 always returns silently, regardless of split layout."""
         pred, evalu = _make_horizon_dataset()
@@ -196,6 +201,27 @@ class TestAssertEmbargoRespected:
                 evalu,
                 embargo=pd.Timedelta(days=1),
             )
+
+    def test_observation_embargo_violation_raises(self) -> None:
+        pred, evalu = _make_horizon_dataset()
+        with pytest.raises(EmbargoViolationError, match="row 10"):
+            assert_embargo_respected(
+                np.array([10, 13]),
+                np.arange(5, 10),
+                pred,
+                evalu,
+                embargo_observations=2,
+            )
+
+    def test_fractional_embargo_clean_split_is_silent(self) -> None:
+        pred, evalu = _make_horizon_dataset(n=20)
+        assert_embargo_respected(
+            np.array([12, 13]),
+            np.arange(5, 10),
+            pred,
+            evalu,
+            embargo_fraction=0.1,
+        )
 
 
 class TestAssertGroupsDisjoint:

--- a/tests/test_embargo.py
+++ b/tests/test_embargo.py
@@ -161,6 +161,115 @@ class TestApplyEmbargo:
         np.testing.assert_array_equal(result, expected)
 
 
+class TestApplyPositionalEmbargo:
+    def test_observation_count_drops_exact_post_test_rows(self) -> None:
+        pred, evalu = _make_horizon_dataset()
+        train_idx = np.concatenate([np.arange(0, 5), np.arange(10, 20)])
+
+        result = apply_embargo(
+            train_idx,
+            np.arange(5, 10),
+            pred,
+            evalu,
+            embargo_observations=3,
+        )
+
+        np.testing.assert_array_equal(result, np.concatenate([np.arange(0, 5), np.arange(13, 20)]))
+
+    def test_fraction_uses_full_dataset_size_and_rounds_down(self) -> None:
+        pred, evalu = _make_horizon_dataset(n=20)
+        train_idx = np.concatenate([np.arange(0, 5), np.arange(10, 20)])
+
+        result = apply_embargo(
+            train_idx,
+            np.arange(5, 10),
+            pred,
+            evalu,
+            embargo_fraction=0.19,
+        )
+
+        # floor(20 * 0.19) == 3
+        np.testing.assert_array_equal(result, np.concatenate([np.arange(0, 5), np.arange(13, 20)]))
+
+    def test_disjoint_test_blocks_each_get_a_positional_window(self) -> None:
+        pred, evalu = _make_horizon_dataset(n=15)
+        train_idx = np.array([3, 4, 5, 6, 7, 8, 12, 13, 14])
+        test_idx = np.array([0, 1, 2, 9, 10, 11])
+
+        result = apply_embargo(
+            train_idx,
+            test_idx,
+            pred,
+            evalu,
+            embargo_observations=2,
+        )
+
+        np.testing.assert_array_equal(result, np.array([5, 6, 7, 8, 14]))
+
+    def test_preserves_unsorted_train_order_and_dtype(self) -> None:
+        pred, evalu = _make_horizon_dataset()
+        train_idx = np.array([15, 11, 2, 10, 14], dtype=np.int32)
+
+        result = apply_embargo(
+            train_idx,
+            np.arange(5, 10),
+            pred,
+            evalu,
+            embargo_observations=2,
+        )
+
+        np.testing.assert_array_equal(result, np.array([15, 2, 14], dtype=np.int32))
+        assert result.dtype == np.int32
+
+    @pytest.mark.parametrize(
+        ("kwargs", "error", "message"),
+        [
+            ({"embargo_observations": -1}, ValueError, "at least 0"),
+            ({"embargo_observations": 1.5}, TypeError, "integer"),
+            ({"embargo_observations": True}, TypeError, "integer"),
+            ({"embargo_fraction": -0.01}, ValueError, r"\[0, 1\]"),
+            ({"embargo_fraction": 1.01}, ValueError, r"\[0, 1\]"),
+            ({"embargo_fraction": float("nan")}, ValueError, r"\[0, 1\]"),
+            ({"embargo_fraction": "0.1"}, TypeError, "real number"),
+            ({"embargo_fraction": True}, TypeError, "real number"),
+        ],
+    )
+    def test_rejects_invalid_positional_configuration(
+        self,
+        kwargs: dict[str, object],
+        error: type[Exception],
+        message: str,
+    ) -> None:
+        pred, evalu = _make_horizon_dataset()
+        with pytest.raises(error, match=message):
+            apply_embargo(
+                np.arange(10, 20),
+                np.arange(5, 10),
+                pred,
+                evalu,
+                **kwargs,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"embargo": "1D", "embargo_observations": 1},
+            {"embargo": "1D", "embargo_fraction": 0.1},
+            {"embargo_observations": 1, "embargo_fraction": 0.1},
+        ],
+    )
+    def test_embargo_modes_are_mutually_exclusive(self, kwargs: dict[str, object]) -> None:
+        pred, evalu = _make_horizon_dataset()
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            apply_embargo(
+                np.arange(10, 20),
+                np.arange(5, 10),
+                pred,
+                evalu,
+                **kwargs,  # type: ignore[arg-type]
+            )
+
+
 def test_apply_embargo_numpy_matches_pandas() -> None:
     from purgedcv import apply_embargo
 

--- a/tests/test_pbo.py
+++ b/tests/test_pbo.py
@@ -114,6 +114,21 @@ class TestPBOPurgePath:
         assert 0.0 <= result.pbo <= 1.0
         assert result.n_combos == comb(8, 4)
 
+    def test_fractional_embargo_runs_through_cscv(self) -> None:
+        rng = np.random.default_rng(23)
+        returns = rng.standard_normal((6, 192)) * 0.01
+        pred = pd.Series(pd.date_range("2024-01-01", periods=192, freq="D"))
+        result = probability_of_backtest_overfitting(
+            returns,
+            n_splits=8,
+            prediction_times=pred,
+            evaluation_times=pred,
+            embargo_fraction=0.01,
+        )
+
+        assert 0.0 <= result.pbo <= 1.0
+        assert result.n_combos == comb(8, 4)
+
     def test_custom_metric_is_used(self) -> None:
         rng = np.random.default_rng(22)
         returns = rng.standard_normal((5, 160)) * 0.01
@@ -157,6 +172,10 @@ class TestPBOValidation:
     def test_rejects_purge_without_times(self) -> None:
         with pytest.raises(ValueError, match="prediction_times and evaluation_times"):
             probability_of_backtest_overfitting(self._returns(), n_splits=4, purge_horizon="1D")
+
+    def test_rejects_positional_embargo_without_times(self) -> None:
+        with pytest.raises(ValueError, match="prediction_times and evaluation_times"):
+            probability_of_backtest_overfitting(self._returns(), n_splits=4, embargo_observations=1)
 
     def test_rejects_time_length_mismatch(self) -> None:
         returns = self._returns()  # (5, 160)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,7 +1,7 @@
-"""Pin the v0.3.0a public API surface of purgedcv.
+"""Pin the maintained 0.1.x public API surface of purgedcv.
 
 These tests are an explicit contract: every name listed here is part of
-the v0.3.0a stable surface that users may rely on. Adding or removing
+the 0.1.x stable surface that users may rely on. Adding or removing
 exports must be a deliberate, reviewed change accompanied by an update
 to this file.
 """
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections.abc import Callable
+from inspect import signature
 
 import numpy as np
 import pandas as pd
@@ -89,6 +91,27 @@ class TestTopLevelAPI:
         allowed_extras = {"exceptions", "optuna_integration"}
         truly_unexpected = unexpected - allowed_extras
         assert not truly_unexpected, f"unexpected public names: {sorted(truly_unexpected)}"
+
+    @pytest.mark.parametrize(
+        "callable_obj",
+        [
+            purgedcv.apply_embargo,
+            purgedcv.WalkForwardSplit,
+            purgedcv.PurgedKFold,
+            purgedcv.PurgedGroupKFold,
+            purgedcv.CombinatorialPurgedCV,
+            purgedcv.CombinatoriallySymmetricCV,
+            purgedcv.probability_of_backtest_overfitting,
+            purgedcv.diagnostics.assert_embargo_respected,
+        ],
+    )
+    def test_embargo_modes_are_available_across_public_api(
+        self, callable_obj: Callable[..., object]
+    ) -> None:
+        parameters = signature(callable_obj).parameters
+        assert "embargo" in parameters
+        assert "embargo_observations" in parameters
+        assert "embargo_fraction" in parameters
 
 
 class TestDiagnosticsSubmodule:

--- a/tests/test_purge_embargo_properties.py
+++ b/tests/test_purge_embargo_properties.py
@@ -126,6 +126,52 @@ class TestEmbargoProperties:
         identity = apply_embargo(train_idx, test_idx, pred, evalu, embargo=pd.Timedelta(0))
         np.testing.assert_array_equal(identity, train_idx)
 
+    @settings(max_examples=200, deadline=None)
+    @given(dataset_and_split(), st.integers(min_value=0, max_value=10))
+    def test_observation_embargo_matches_diagnostic(
+        self,
+        case: tuple[pd.Series, pd.Series, NDArrayAny, NDArrayAny],
+        observations: int,
+    ) -> None:
+        pred, evalu, train_idx, test_idx = case
+        embargoed = apply_embargo(
+            train_idx,
+            test_idx,
+            pred,
+            evalu,
+            embargo_observations=observations,
+        )
+        assert_embargo_respected(
+            embargoed,
+            test_idx,
+            pred,
+            evalu,
+            embargo_observations=observations,
+        )
+
+    @settings(max_examples=100, deadline=None)
+    @given(dataset_and_split(), st.floats(min_value=0.0, max_value=1.0))
+    def test_fractional_embargo_matches_diagnostic(
+        self,
+        case: tuple[pd.Series, pd.Series, NDArrayAny, NDArrayAny],
+        fraction: float,
+    ) -> None:
+        pred, evalu, train_idx, test_idx = case
+        embargoed = apply_embargo(
+            train_idx,
+            test_idx,
+            pred,
+            evalu,
+            embargo_fraction=fraction,
+        )
+        assert_embargo_respected(
+            embargoed,
+            test_idx,
+            pred,
+            evalu,
+            embargo_fraction=fraction,
+        )
+
 
 class TestPurgePlusEmbargoComposition:
     @settings(max_examples=200, deadline=None)

--- a/tests/test_purged_kfold.py
+++ b/tests/test_purged_kfold.py
@@ -17,6 +17,22 @@ def _times(n: int = 20, horizon_days: int = 1) -> tuple[pd.Series, pd.Series]:
 
 
 class TestPurgedKFold:
+    def test_fractional_embargo_drops_post_test_rows(self) -> None:
+        pred, evalu = _times(n=20, horizon_days=1)
+        cv = PurgedKFold(
+            n_splits=4,
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_fraction=0.1,
+        )
+
+        train_idx, test_idx = list(cv.split(np.zeros((20, 1))))[1]
+
+        np.testing.assert_array_equal(test_idx, np.arange(5, 10))
+        assert 10 not in train_idx
+        assert 11 not in train_idx
+        assert 12 in train_idx
+
     def test_yields_n_splits_folds(self) -> None:
         pred, evalu = _times(n=20)
         cv = PurgedKFold(
@@ -139,6 +155,22 @@ class TestPurgedKFold:
 
 
 class TestPurgedGroupKFold:
+    def test_positional_embargo_applies_after_each_interleaved_test_run(self) -> None:
+        pred, evalu = _times(n=24)
+        groups = np.arange(24) % 6
+        cv = PurgedGroupKFold(
+            n_splits=3,
+            prediction_times=pred,
+            evaluation_times=evalu,
+            groups=groups,
+            embargo_observations=2,
+        )
+
+        train_idx, test_idx = next(cv.split(np.zeros((24, 1))))
+
+        np.testing.assert_array_equal(test_idx, np.array([0, 1, 6, 7, 12, 13, 18, 19]))
+        np.testing.assert_array_equal(train_idx, np.array([4, 5, 10, 11, 16, 17, 22, 23]))
+
     def test_yields_n_splits_folds(self) -> None:
         """6 patients, 5 observations each (30 rows), n_splits=3."""
         pred = pd.Series(pd.date_range("2024-01-01", periods=30, freq="D"))

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -16,6 +16,29 @@ def _times(n: int = 20, horizon_days: int = 1) -> tuple[pd.Series, pd.Series]:
 
 
 class TestWalkForwardSplit:
+    def test_post_test_observation_embargo_is_noop_by_design(self) -> None:
+        pred, evalu = _times(n=24)
+        baseline = WalkForwardSplit(
+            n_splits=3,
+            test_size=4,
+            prediction_times=pred,
+            evaluation_times=evalu,
+        )
+        with_embargo = WalkForwardSplit(
+            n_splits=3,
+            test_size=4,
+            prediction_times=pred,
+            evaluation_times=evalu,
+            embargo_observations=5,
+        )
+        X = np.zeros((24, 1))  # noqa: N806
+
+        for (base_train, base_test), (emb_train, emb_test) in zip(
+            baseline.split(X), with_embargo.split(X), strict=True
+        ):
+            np.testing.assert_array_equal(emb_train, base_train)
+            np.testing.assert_array_equal(emb_test, base_test)
+
     def test_yields_n_splits_folds(self) -> None:
         pred, evalu = _times(n=20)
         cv = WalkForwardSplit(


### PR DESCRIPTION
## What changes

Add observation-based embargoes alongside the existing duration-based mode.
Users can now select exactly one of:

- `embargo` for a wall-clock duration;
- `embargo_observations` for a fixed number of post-test row positions;
- `embargo_fraction` for `floor(n_samples * fraction)` post-test row
  positions.

The new modes are available consistently in the row-level embargo helper,
temporal splitters, PBO, and embargo diagnostics. Positional embargoes are
applied after every contiguous run of test positions, which also gives CPCV
and non-contiguous group folds well-defined behaviour. Existing
duration-based behaviour remains unchanged.

This makes embargo configuration practical for bar-based datasets where a
fixed number or proportion of observations is more meaningful than elapsed
wall-clock time. Validation, public API coverage, property tests, end-to-end
tests, API documentation, examples, README files, and the changelog have been
updated with the implementation.

## Checklist

- [x] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [x] `mypy src tests` is clean.
- [ ] `pytest -q` is green locally.
- [x] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
- [x] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
- [x] If the docs site is affected, `mkdocs build --strict` is clean.
- [x] `CHANGELOG.md` has an entry under `Unreleased`, if the change is
      user-visible.

## Notes for the reviewer

- The three embargo modes are mutually exclusive. Zero observations, a zero
  fraction, and a zero duration are accepted as explicit no-op modes.
- `embargo_fraction` is calculated from the full dataset size and rounded
  down once before it is applied to each contiguous test run.
- For `PurgedGroupKFold`, interleaved group labels may create several
  contiguous test runs. Positional embargo is applied after each run and can
  therefore remove more rows than a single-block fold.
- `WalkForwardSplit` accepts the new parameters for constructor consistency,
  but all post-test embargo modes are no-ops there: its training rows are
  strictly before the test block. Purging still applies.
- `assert_embargo_respected` now requires an explicit embargo mode instead of
  silently treating an omitted mode as a zero-duration check.
- The focused regression suite passes (`85 passed`), and the non-e2e suite
  passes with `473 passed` and total coverage of `97.63%`. A full e2e run also
  passed with deprecation warnings suppressed. Bare `pytest -q` remains
  unchecked because the local pandas/NumPy combination emits
  `DeprecationWarning` text in subprocess tests that assert an empty stderr;
  this is unrelated to the embargo implementation.
- Documentation catalogs now list all 15 shipped notebooks. The historical
  `0.1.3` changelog date was also aligned with its release commit.
