### PR TITLE
feat: add audit_splitter function for detailed per-fold diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Plan is listed under the published version it shipped in.
 
 ### Added
 
+- New public `audit_splitter(cv, X)` diagnostic returns one DataFrame row per
+  fold with candidate and final train sizes, purge/embargo/window removal
+  counts, `candidate_overlap_fraction` and `final_overlap_fraction`, train/test
+  time bounds, and group-disjointness status. It consumes the splitters' real
+  candidate → purged → embargoed stages instead of inferring removal counts
+  from final indices; leakage is reported rather than raised.
 - Embargo can now be expressed in three mutually exclusive ways throughout
   the splitter, PBO, row-level, and diagnostics APIs: a wall-clock duration
   (`embargo`), a fixed number of post-test rows (`embargo_observations`), or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Plan is listed under the published version it shipped in.
 
 - New public `audit_splitter(cv, X)` diagnostic returns one DataFrame row per
   fold with candidate and final train sizes, purge/embargo/window removal
-  counts, `candidate_overlap_fraction` and `final_overlap_fraction`, train/test
-  time bounds, and group-disjointness status. It consumes the splitters' real
+  counts, indices added during custom finalization,
+  `candidate_overlap_fraction` and `final_overlap_fraction`, train/test time
+  bounds, and group-disjointness status. It consumes the splitters' real
   candidate → purged → embargoed stages instead of inferring removal counts
   from final indices; leakage is reported rather than raised.
 - Embargo can now be expressed in three mutually exclusive ways throughout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ Plan is listed under the published version it shipped in.
 ### Added
 
 - New public `audit_splitter(cv, X)` diagnostic returns one DataFrame row per
-  fold with candidate and final train sizes, purge/embargo/window removal
-  counts, indices added during custom finalization,
+  fold with candidate and final train sizes, purge/embargo/finalization
+  removal counts, indices added during custom finalization,
   `candidate_overlap_fraction` and `final_overlap_fraction`, train/test time
-  bounds, and group-disjointness status. It consumes the splitters' real
+  envelopes with contiguous-block counts, train non-emptiness, and
+  group-disjointness status. It consumes the splitters' real
   candidate → purged → embargoed stages instead of inferring removal counts
-  from final indices; leakage is reported rather than raised.
+  from final indices; leakage is reported rather than raised. Subclasses that
+  override `split()` are rejected because their returned folds can diverge
+  from that auditable pipeline, and custom final indices are validated for
+  positional correctness and uniqueness.
 - Embargo can now be expressed in three mutually exclusive ways throughout
   the splitter, PBO, row-level, and diagnostics APIs: a wall-clock duration
   (`embargo`), a fixed number of post-test rows (`embargo_observations`), or a

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 | `minimum_backtest_length` | D7 | MinBTL: backtest years below which a Sharpe is selection luck |
 | `effective_n_trials` | D7 | Independent-trial count for a correlated search, for DSR |
 | `optuna_integration.TrialSharpeRecorder` | D7 | Collect per-trial Sharpe variance + effective count for DSR |
-| `audit_splitter` | D8 | Per-fold purge, embargo, overlap, bounds, and group audit report |
+| `audit_splitter` | D8 | Per-fold filtering, overlap, block/envelope, and group audit report |
 | `diagnostics.*` | D8 | Leakage and embargo audit functions |
 
 ---

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 | `minimum_backtest_length` | D7 | MinBTL: backtest years below which a Sharpe is selection luck |
 | `effective_n_trials` | D7 | Independent-trial count for a correlated search, for DSR |
 | `optuna_integration.TrialSharpeRecorder` | D7 | Collect per-trial Sharpe variance + effective count for DSR |
+| `audit_splitter` | D8 | Per-fold purge, embargo, overlap, bounds, and group audit report |
 | `diagnostics.*` | D8 | Leakage and embargo audit functions |
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,8 @@ contract.
 
 ## Diagnostics
 
+::: purgedcv.audit_splitter
+
 ::: purgedcv.diagnostics.compute_overlap_fraction
 
 ::: purgedcv.diagnostics.assert_no_temporal_leakage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ flowchart TB
         splitters["Splitters · sklearn protocol<br/>WalkForwardSplit (D5.1)<br/>PurgedKFold (D5.2)<br/>PurgedGroupKFold (D5.3)<br/>CombinatorialPurgedCV (D5.4)"]
         paths["reconstruct_paths /<br/>backtest_paths (D6)"]
         metrics["Statistical metrics (D7)<br/>probabilistic_sharpe_ratio<br/>deflated_sharpe_ratio<br/>min_track_record_length"]
-        diagnostics["Diagnostics (D8)<br/>compute_overlap_fraction<br/>assert_no_temporal_leakage<br/>assert_groups_disjoint<br/>assert_embargo_respected"]
+        diagnostics["Diagnostics (D8)<br/>audit_splitter<br/>compute_overlap_fraction<br/>assert_no_temporal_leakage<br/>assert_groups_disjoint<br/>assert_embargo_respected"]
     end
 
     subgraph internal["Internal kernel"]
@@ -43,6 +43,7 @@ flowchart TB
     paths --> metrics
 
     user -.audit any custom split.-> diagnostics
+    diagnostics -.audit purgedcv fold stages.-> base
     diagnostics --> intervals
     diagnostics --> time
 ```
@@ -67,12 +68,13 @@ Three small invariants keep the surface honest.
    single hand-tuned `gap` and still be correct — the user passes the
    actual horizon and the splitter does the right thing per row.
 
-3. **Diagnostics are independent.** `compute_overlap_fraction` and the
-   three `assert_*` functions accept positional indices, the same
-   timestamp series, and an optional purge horizon. They never assume
-   their input came from `purgedcv` — they audit any split (sklearn,
-   tscv, hand-rolled) the same way. The competitor benchmark on the
-   docs site uses them to score every library on equal terms.
+3. **Row-level diagnostics are independent; splitter audits share the real
+   pipeline.** `compute_overlap_fraction` and the three `assert_*` functions
+   accept positional indices and never assume their input came from
+   `purgedcv`, so they can audit sklearn, tscv, or hand-rolled splits equally.
+   `audit_splitter` deliberately targets `BaseTemporalSplitter`: it consumes
+   the same candidate → purge → embargo → final stages as `split()` so its
+   per-stage counts are observed rather than inferred.
 
 ## Module layout
 
@@ -91,7 +93,7 @@ src/purgedcv/
 ├── _metrics.py          probabilistic_sharpe_ratio, deflated_sharpe_ratio,
 │                        min_track_record_length
 ├── _typing.py           NDArrayAny, HorizonLike
-├── diagnostics.py       public audit functions
+├── diagnostics.py       public assertions and per-fold audit report
 ├── exceptions.py        TemporalCVError tree
 └── py.typed             PEP 561 marker — the package is fully typed
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,10 @@ Three small invariants keep the surface honest.
    `purgedcv`, so they can audit sklearn, tscv, or hand-rolled splits equally.
    `audit_splitter` deliberately targets `BaseTemporalSplitter`: it consumes
    the same candidate → purge → embargo → final stages as `split()` so its
-   per-stage counts are observed rather than inferred.
+   per-stage counts are observed rather than inferred. Subclasses must express
+   fold customization through the stage hooks; overriding `split()` is
+   rejected because the report could no longer guarantee it audits the folds
+   users actually receive.
 
 ## Module layout
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -118,6 +118,8 @@ print(report[[
     "final_train_size",
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
+    "rows_removed_by_window",
+    "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
 ]])
@@ -130,9 +132,11 @@ using the splitter's configured `purge_horizon`; reproduce the same number with
 `temporal_leakage_free` is therefore expected to be true; it mainly guards
 custom splitter finalization hooks from accidentally reintroducing indices.
 For sliding walk-forward splits, `rows_removed_by_window` keeps window
-truncation distinct from purge and embargo. The report records leakage and
-group overlap as values instead of raising, while malformed inputs still fail
-validation normally.
+truncation distinct from purge and embargo. Built-in splitters never add rows
+during finalization, so `rows_added_by_finalization` is zero; a positive value
+flags a custom finalizer that introduced or swapped indices. The report records
+leakage and group overlap as values instead of raising, while malformed inputs
+still fail validation normally.
 
 ### Sample weights
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -101,6 +101,39 @@ print("honest R^2 per fold:", scores)
 (chronological train-on-the-past, expanding or rolling) follow the same
 constructor pattern.
 
+### Audit what each fold removed
+
+Before running a large model search, inspect the splitter itself with
+`audit_splitter`. It uses the same internal fold pipeline as `split()` and
+reports each filtering stage rather than trying to reconstruct it from the
+final indices.
+
+```python
+from purgedcv import audit_splitter
+
+report = audit_splitter(cv, features)
+print(report[[
+    "fold",
+    "candidate_train_size",
+    "final_train_size",
+    "rows_removed_by_purge",
+    "rows_removed_by_embargo",
+    "candidate_overlap_fraction",
+    "final_overlap_fraction",
+]])
+```
+
+`candidate_overlap_fraction` describes the unfiltered candidate train set
+using the splitter's configured `purge_horizon`; reproduce the same number with
+`compute_overlap_fraction(..., purge_horizon=cv.purge_horizon)`.
+`final_overlap_fraction` should be zero. For built-in splitters,
+`temporal_leakage_free` is therefore expected to be true; it mainly guards
+custom splitter finalization hooks from accidentally reintroducing indices.
+For sliding walk-forward splits, `rows_removed_by_window` keeps window
+truncation distinct from purge and embargo. The report records leakage and
+group overlap as values instead of raising, while malformed inputs still fail
+validation normally.
+
 ### Sample weights
 
 The splitters carry no scorer of their own; they stay drop-in to

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -116,27 +116,42 @@ print(report[[
     "fold",
     "candidate_train_size",
     "final_train_size",
+    "train_nonempty",
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
-    "rows_removed_by_window",
+    "rows_removed_by_finalization",
     "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
+    "train_block_count",
+    "test_block_count",
 ]])
 ```
 
 `candidate_overlap_fraction` describes the unfiltered candidate train set
-using the splitter's configured `purge_horizon`; reproduce the same number with
-`compute_overlap_fraction(..., purge_horizon=cv.purge_horizon)`.
-`final_overlap_fraction` should be zero. For built-in splitters,
-`temporal_leakage_free` is therefore expected to be true; it mainly guards
-custom splitter finalization hooks from accidentally reintroducing indices.
-For sliding walk-forward splits, `rows_removed_by_window` keeps window
-truncation distinct from purge and embargo. Built-in splitters never add rows
-during finalization, so `rows_added_by_finalization` is zero; a positive value
-flags a custom finalizer that introduced or swapped indices. The report records
-leakage and group overlap as values instead of raising, while malformed inputs
-still fail validation normally.
+using the splitter's configured `purge_horizon`. For a non-empty candidate set
+it equals `rows_removed_by_purge / candidate_train_size`; it is defined as zero
+when the candidate set is empty. Indices returned by `cv.split()` are already
+final, so passing them to `compute_overlap_fraction` reproduces
+`final_overlap_fraction`, not the candidate value. The standalone function can
+reproduce the candidate value only when you already own the pre-purge indices
+of a custom split and pass the same purge horizon.
+
+For built-in splitters, `final_overlap_fraction` should be zero and
+`temporal_leakage_free` true. On an empty train set that truth is vacuous, so
+check `train_nonempty` before treating a fold as usable. A sliding
+`WalkForwardSplit` performs its window truncation during finalization, hence
+the count appears under `rows_removed_by_finalization`. Built-in splitters
+never add rows there; a positive `rows_added_by_finalization` flags a custom
+finalizer that introduced or swapped indices.
+
+The four time-envelope columns are outer bounds, not claims that the rows form
+one continuous window. CPCV folds can have several disjoint blocks whose train
+and test envelopes overlap while the actual horizons remain clean; use
+`train_block_count`, `test_block_count`, and `final_overlap_fraction` together.
+Subclasses that override `split()` cannot be audited and raise a clear error;
+customize the documented internal hooks instead. Malformed inputs and final
+indices also fail validation normally.
 
 ### Sample weights
 

--- a/src/purgedcv/__init__.py
+++ b/src/purgedcv/__init__.py
@@ -20,6 +20,7 @@ from purgedcv._purged_kfold import PurgedGroupKFold, PurgedKFold
 from purgedcv._time import horizons_overlap, parse_horizon, validate_times
 from purgedcv._typing import ArrayLike1D, TimesLike
 from purgedcv._walk_forward import WalkForwardSplit
+from purgedcv.diagnostics import audit_splitter
 from purgedcv.exceptions import (
     EmbargoViolationError,
     GroupLeakageError,
@@ -44,6 +45,7 @@ __all__ = [
     "WalkForwardSplit",
     "__version__",
     "apply_embargo",
+    "audit_splitter",
     "default_backtest_metrics",
     "deflated_sharpe_ratio",
     "deflated_sharpe_ratio_full",

--- a/src/purgedcv/_base.py
+++ b/src/purgedcv/_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -13,9 +14,19 @@ from purgedcv._embargo import _validate_embargo_modes, apply_embargo
 from purgedcv._purge import purge
 from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
 from purgedcv._validation import _validate_positional_indices
-from purgedcv.diagnostics import assert_groups_disjoint
 
 from ._typing import ArrayLike1D, NDArrayAny, TimesLike
+
+
+@dataclass(frozen=True)
+class _SplitStages:
+    """Internal snapshots of the train-index filtering pipeline."""
+
+    candidate_train_idx: NDArrayAny
+    purged_train_idx: NDArrayAny
+    embargoed_train_idx: NDArrayAny
+    final_train_idx: NDArrayAny
+    test_idx: NDArrayAny
 
 
 class BaseTemporalSplitter(ABC):
@@ -105,24 +116,46 @@ class BaseTemporalSplitter(ABC):
 
         When groups were bound at construction,
         :func:`~purgedcv.diagnostics.assert_groups_disjoint` is called on
-        every fold after purge and embargo; a
+        every fold after purge, embargo, and splitter-specific finalization; a
         :class:`~purgedcv.exceptions.GroupLeakageError` is raised if any
         group identifier appears in both train and test of the same fold.
+        """
+        for stages in self._iter_split_stages(X):
+            train_idx = stages.final_train_idx
+            test_idx = stages.test_idx
+            if self._groups is not None:
+                # Local import keeps diagnostics free to depend on the base
+                # splitter for the public audit_splitter type and pipeline.
+                from purgedcv.diagnostics import assert_groups_disjoint
+
+                assert_groups_disjoint(train_idx, test_idx, self._groups)
+            yield train_idx, test_idx
+
+    def _iter_split_stages(
+        self,
+        X: NDArrayAny | pd.DataFrame,  # noqa: N803
+    ) -> Iterator[_SplitStages]:
+        """Yield each real candidate → purge → embargo → final pipeline.
+
+        This is the single orchestration path used by :meth:`split` and the
+        public :func:`purgedcv.audit_splitter` report. Keeping the intermediate
+        arrays here prevents diagnostics from guessing purge and embargo
+        effects by comparing only the final split indices.
         """
         n_samples = self._n_samples_or_check(X)
 
         for test_idx in self._iter_test_indices(n_samples):
             test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=n_samples)
-            train_idx = self._candidate_train_idx(n_samples, test_idx)
-            train_idx = purge(
-                train_idx,
+            candidate_train_idx = self._candidate_train_idx(n_samples, test_idx)
+            purged_train_idx = purge(
+                candidate_train_idx,
                 test_idx,
                 self._prediction_times,
                 self._evaluation_times,
                 purge_horizon=self.purge_horizon,
             )
-            train_idx = apply_embargo(
-                train_idx,
+            embargoed_train_idx = apply_embargo(
+                purged_train_idx,
                 test_idx,
                 self._prediction_times,
                 self._evaluation_times,
@@ -134,9 +167,14 @@ class BaseTemporalSplitter(ABC):
                 embargo_observations=self.embargo_observations,
                 embargo_fraction=self.embargo_fraction,
             )
-            if self._groups is not None:
-                assert_groups_disjoint(train_idx, test_idx, self._groups)
-            yield train_idx, test_idx
+            final_train_idx = self._finalize_train_idx(embargoed_train_idx, test_idx)
+            yield _SplitStages(
+                candidate_train_idx=candidate_train_idx,
+                purged_train_idx=purged_train_idx,
+                embargoed_train_idx=embargoed_train_idx,
+                final_train_idx=final_train_idx,
+                test_idx=test_idx,
+            )
 
     def _candidate_train_idx(self, n_samples: int, test_idx: NDArrayAny) -> NDArrayAny:
         """Return the candidate training indices BEFORE purge and embargo
@@ -153,6 +191,14 @@ class BaseTemporalSplitter(ABC):
         mask = np.ones(n_samples, dtype=bool)
         mask[test_idx] = False
         return np.where(mask)[0].astype(np.int64)
+
+    def _finalize_train_idx(
+        self,
+        train_idx: NDArrayAny,
+        test_idx: NDArrayAny,
+    ) -> NDArrayAny:
+        """Apply splitter-specific filtering after purge and embargo."""
+        return train_idx
 
     def with_times(
         self,

--- a/src/purgedcv/_base.py
+++ b/src/purgedcv/_base.py
@@ -43,9 +43,9 @@ class BaseTemporalSplitter(ABC):
 
     .. note::
        The subclassing interface (``_iter_test_indices``,
-       ``_candidate_train_idx``) is an implementation detail, not part of the
-       maintained ``0.1.x`` public contract. Subclasses may need adjustments
-       before v1.0.
+       ``_candidate_train_idx``, ``_finalize_train_idx``) is an implementation
+       detail, not part of the maintained ``0.1.x`` public contract.
+       Subclasses may need adjustments before v1.0.
     """
 
     def __init__(
@@ -120,14 +120,14 @@ class BaseTemporalSplitter(ABC):
         :class:`~purgedcv.exceptions.GroupLeakageError` is raised if any
         group identifier appears in both train and test of the same fold.
         """
+        # Local import avoids the module-level BaseTemporalSplitter ↔
+        # diagnostics cycle while doing the cached import only once per split.
+        from purgedcv.diagnostics import assert_groups_disjoint
+
         for stages in self._iter_split_stages(X):
             train_idx = stages.final_train_idx
             test_idx = stages.test_idx
             if self._groups is not None:
-                # Local import keeps diagnostics free to depend on the base
-                # splitter for the public audit_splitter type and pipeline.
-                from purgedcv.diagnostics import assert_groups_disjoint
-
                 assert_groups_disjoint(train_idx, test_idx, self._groups)
             yield train_idx, test_idx
 
@@ -167,7 +167,11 @@ class BaseTemporalSplitter(ABC):
                 embargo_observations=self.embargo_observations,
                 embargo_fraction=self.embargo_fraction,
             )
-            final_train_idx = self._finalize_train_idx(embargoed_train_idx, test_idx)
+            final_train_idx = _validate_positional_indices(
+                "final_train_idx",
+                self._finalize_train_idx(embargoed_train_idx, test_idx),
+                n_samples=n_samples,
+            )
             yield _SplitStages(
                 candidate_train_idx=candidate_train_idx,
                 purged_train_idx=purged_train_idx,

--- a/src/purgedcv/_walk_forward.py
+++ b/src/purgedcv/_walk_forward.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import Literal
 
 import numpy as np
-import pandas as pd
 
 from purgedcv._base import BaseTemporalSplitter
 from purgedcv._time import HorizonLike
@@ -160,25 +158,16 @@ class WalkForwardSplit(BaseTemporalSplitter):
         test_start = int(test_idx.min())
         return np.arange(test_start, dtype=np.int64)
 
-    def split(
+    def _finalize_train_idx(
         self,
-        X: NDArrayAny | pd.DataFrame,  # noqa: N803
-        y: object = None,
-        groups: object = None,
-    ) -> Iterator[tuple[NDArrayAny, NDArrayAny]]:
-        """Yield ``(train_idx, test_idx)`` pairs for each walk-forward fold.
+        train_idx: NDArrayAny,
+        test_idx: NDArrayAny,
+    ) -> NDArrayAny:
+        """Trim the post-purge train set for sliding-window semantics.
 
-        The base class handles X length validation, purge, and embargo;
-        this override additionally trims each training set to the most
-        recent ``train_size`` rows when ``window="sliding"``. Training
-        indices are always strictly less than the minimum index of the
-        test fold (the defining walk-forward property).
-
-        The number of pairs yielded equals ``self.n_splits``. The ``y``
-        and ``groups`` arguments are accepted for sklearn protocol
-        compatibility but ignored.
+        ``test_idx`` is accepted as part of the shared finalization hook; the
+        walk-forward window depends only on the already ordered train rows.
         """
-        for train_idx, test_idx in super().split(X, y=y, groups=groups):
-            if self.window == "sliding" and self.train_size is not None:
-                train_idx = train_idx[-self.train_size :]
-            yield train_idx, test_idx
+        if self.window == "sliding" and self.train_size is not None:
+            return train_idx[-self.train_size :]
+        return train_idx

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -47,6 +47,7 @@ _AUDIT_COLUMNS = (
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
     "rows_removed_by_window",
+    "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
     "temporal_leakage_free",
@@ -98,6 +99,16 @@ def _group_overlap_from_arrays(
     return train_groups & test_groups
 
 
+def _index_membership_changes(
+    before: NDArrayAny,
+    after: NDArrayAny,
+) -> tuple[int, int]:
+    """Count indices removed from and added to a finalization stage."""
+    before_set = set(before.tolist())
+    after_set = set(after.tolist())
+    return len(before_set - after_set), len(after_set - before_set)
+
+
 def audit_splitter(
     cv: BaseTemporalSplitter,
     X: NDArrayAny | pd.DataFrame,  # noqa: N803
@@ -108,7 +119,9 @@ def audit_splitter(
     as :meth:`BaseTemporalSplitter.split`; purge and embargo counts therefore
     come from the actual intermediate index arrays rather than being inferred
     from the final split. Sliding walk-forward truncation is reported
-    separately as ``rows_removed_by_window``.
+    separately as ``rows_removed_by_window``. If a custom finalization hook
+    introduces indices, ``rows_added_by_finalization`` reports them rather
+    than allowing the removal count to become negative or conceal a swap.
 
     ``candidate_overlap_fraction`` is the fraction of candidate training rows
     whose label horizons overlap the test horizons after applying the
@@ -133,9 +146,10 @@ def audit_splitter(
     Returns:
         A DataFrame with one row per fold. Columns contain the zero-based fold
         number; candidate, final, and test sizes; rows removed at the purge,
-        embargo, and splitter-specific window stages; candidate and final
-        temporal-overlap fractions; final train and test label-horizon bounds;
-        and ``groups_disjoint`` (``None`` when no groups are bound).
+        embargo, and splitter-specific window stages; indices added by custom
+        finalization; candidate and final temporal-overlap fractions; final
+        train and test label-horizon bounds; and ``groups_disjoint`` (``None``
+        when no groups are bound).
 
     Raises:
         TypeError: if ``cv`` is not a :class:`BaseTemporalSplitter`.
@@ -191,6 +205,9 @@ def audit_splitter(
             groups_disjoint = not _group_overlap_from_arrays(
                 stages.final_train_idx, stages.test_idx, groups
             )
+        removed_by_window, added_by_finalization = _index_membership_changes(
+            stages.embargoed_train_idx, stages.final_train_idx
+        )
 
         rows.append(
             {
@@ -202,8 +219,8 @@ def audit_splitter(
                 - len(stages.purged_train_idx),
                 "rows_removed_by_embargo": len(stages.purged_train_idx)
                 - len(stages.embargoed_train_idx),
-                "rows_removed_by_window": len(stages.embargoed_train_idx)
-                - len(stages.final_train_idx),
+                "rows_removed_by_window": removed_by_window,
+                "rows_added_by_finalization": added_by_finalization,
                 "candidate_overlap_fraction": candidate_overlap,
                 "final_overlap_fraction": final_overlap,
                 "temporal_leakage_free": final_overlap == 0.0,

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -7,15 +7,18 @@ These functions exist for two purposes:
 2. Users audit custom splits they have built by hand.
 
 Each ``assert_*`` raises a specific :class:`TemporalCVError` subclass with
-the offending row index in the message; the non-raising
-:func:`compute_overlap_fraction` returns a scalar summary suitable for
-logging or sanity-checking.
+the offending row index in the message. The non-raising helpers return either
+a scalar overlap summary or a per-fold splitter audit suitable for logging,
+review, and regression checks.
 """
 
 from __future__ import annotations
 
+from typing import Any
+
 import pandas as pd
 
+from purgedcv._base import BaseTemporalSplitter
 from purgedcv._embargo import _positional_embargo_mask, _validate_embargo_modes
 from purgedcv._intervals import overlaps_any_half_open_interval, points_in_any_closed_interval
 from purgedcv._time import HorizonLike, _coerce_1d, parse_horizon, validate_times
@@ -32,8 +35,186 @@ __all__ = [
     "assert_embargo_respected",
     "assert_groups_disjoint",
     "assert_no_temporal_leakage",
+    "audit_splitter",
     "compute_overlap_fraction",
 ]
+
+_AUDIT_COLUMNS = (
+    "fold",
+    "candidate_train_size",
+    "final_train_size",
+    "test_size",
+    "rows_removed_by_purge",
+    "rows_removed_by_embargo",
+    "rows_removed_by_window",
+    "candidate_overlap_fraction",
+    "final_overlap_fraction",
+    "temporal_leakage_free",
+    "train_start_time",
+    "train_end_time",
+    "test_start_time",
+    "test_end_time",
+    "groups_disjoint",
+)
+
+
+def _overlap_fraction_from_arrays(
+    train_idx: NDArrayAny,
+    test_idx: NDArrayAny,
+    prediction_times: NDArrayAny,
+    evaluation_times: NDArrayAny,
+    purge_horizon: pd.Timedelta,
+) -> float:
+    """Compute overlap after public-boundary validation has already run."""
+    if len(train_idx) == 0 or len(test_idx) == 0:
+        return 0.0
+    train_pred = prediction_times[train_idx]
+    train_eval = evaluation_times[train_idx]
+    test_starts = prediction_times[test_idx] - purge_horizon
+    test_ends = evaluation_times[test_idx] + purge_horizon
+    overlaps = overlaps_any_half_open_interval(train_pred, train_eval, test_starts, test_ends)
+    return float(overlaps.mean())
+
+
+def _time_bounds(
+    indices: NDArrayAny,
+    prediction_times: NDArrayAny,
+    evaluation_times: NDArrayAny,
+) -> tuple[object, object]:
+    """Return the label-horizon envelope for a positional index array."""
+    if len(indices) == 0:
+        return pd.NaT, pd.NaT
+    return prediction_times[indices].min(), evaluation_times[indices].max()
+
+
+def _group_overlap_from_arrays(
+    train_idx: NDArrayAny,
+    test_idx: NDArrayAny,
+    groups: NDArrayAny,
+) -> set[Any]:
+    """Return group identifiers shared by train and test arrays."""
+    train_groups = set(groups[train_idx].tolist())
+    test_groups = set(groups[test_idx].tolist())
+    return train_groups & test_groups
+
+
+def audit_splitter(
+    cv: BaseTemporalSplitter,
+    X: NDArrayAny | pd.DataFrame,  # noqa: N803
+) -> pd.DataFrame:
+    """Return a non-raising, per-fold report for a temporal splitter.
+
+    The report consumes the same candidate → purge → embargo → final pipeline
+    as :meth:`BaseTemporalSplitter.split`; purge and embargo counts therefore
+    come from the actual intermediate index arrays rather than being inferred
+    from the final split. Sliding walk-forward truncation is reported
+    separately as ``rows_removed_by_window``.
+
+    ``candidate_overlap_fraction`` is the fraction of candidate training rows
+    whose label horizons overlap the test horizons after applying the
+    splitter's ``purge_horizon`` padding. To reproduce it with
+    :func:`compute_overlap_fraction`, pass the same ``purge_horizon``
+    explicitly. ``final_overlap_fraction`` repeats the measure on the final
+    training rows and should be zero for a clean splitter.
+
+    For the built-in splitters, ``temporal_leakage_free`` is structurally
+    expected to be ``True``: purge removes overlaps and later stages only
+    remove rows. The column is primarily a regression guard for custom
+    :class:`BaseTemporalSplitter` subclasses whose finalization hook could
+    accidentally reintroduce indices; it is not an independent validation
+    algorithm. Leakage and group overlap are reported as values instead of
+    raising; malformed inputs and splitter configuration errors still raise.
+
+    Args:
+        cv: A :class:`BaseTemporalSplitter` instance with times already bound.
+        X: Feature matrix or other sized sample container. Its length must
+            match the times bound to ``cv``; feature values are not inspected.
+
+    Returns:
+        A DataFrame with one row per fold. Columns contain the zero-based fold
+        number; candidate, final, and test sizes; rows removed at the purge,
+        embargo, and splitter-specific window stages; candidate and final
+        temporal-overlap fractions; final train and test label-horizon bounds;
+        and ``groups_disjoint`` (``None`` when no groups are bound).
+
+    Raises:
+        TypeError: if ``cv`` is not a :class:`BaseTemporalSplitter`.
+        ValueError: if ``X`` has the wrong length or the splitter cannot form
+            its configured folds.
+
+    Examples:
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> from purgedcv import PurgedKFold, audit_splitter
+        >>> pred = pd.date_range("2024-01-01", periods=20, freq="D")
+        >>> evalu = pred + pd.Timedelta(days=1)
+        >>> cv = PurgedKFold(
+        ...     4, prediction_times=pred, evaluation_times=evalu,
+        ...     purge_horizon="1D", embargo_observations=2,
+        ... )
+        >>> report = audit_splitter(cv, np.zeros((20, 1)))
+        >>> report.shape[0]
+        4
+        >>> bool(report["final_overlap_fraction"].eq(0.0).all())
+        True
+    """
+    if not isinstance(cv, BaseTemporalSplitter):
+        raise TypeError(
+            f"cv must be a purgedcv BaseTemporalSplitter instance, got {type(cv).__name__}."
+        )
+
+    rows: list[dict[str, object]] = []
+    prediction_times = cv._prediction_times
+    evaluation_times = cv._evaluation_times
+    groups = cv._groups
+    for fold, stages in enumerate(cv._iter_split_stages(X)):
+        candidate_overlap = _overlap_fraction_from_arrays(
+            stages.candidate_train_idx,
+            stages.test_idx,
+            prediction_times,
+            evaluation_times,
+            cv.purge_horizon,
+        )
+        final_overlap = _overlap_fraction_from_arrays(
+            stages.final_train_idx,
+            stages.test_idx,
+            prediction_times,
+            evaluation_times,
+            cv.purge_horizon,
+        )
+        train_start, train_end = _time_bounds(
+            stages.final_train_idx, prediction_times, evaluation_times
+        )
+        test_start, test_end = _time_bounds(stages.test_idx, prediction_times, evaluation_times)
+        groups_disjoint: bool | None = None
+        if groups is not None:
+            groups_disjoint = not _group_overlap_from_arrays(
+                stages.final_train_idx, stages.test_idx, groups
+            )
+
+        rows.append(
+            {
+                "fold": fold,
+                "candidate_train_size": len(stages.candidate_train_idx),
+                "final_train_size": len(stages.final_train_idx),
+                "test_size": len(stages.test_idx),
+                "rows_removed_by_purge": len(stages.candidate_train_idx)
+                - len(stages.purged_train_idx),
+                "rows_removed_by_embargo": len(stages.purged_train_idx)
+                - len(stages.embargoed_train_idx),
+                "rows_removed_by_window": len(stages.embargoed_train_idx)
+                - len(stages.final_train_idx),
+                "candidate_overlap_fraction": candidate_overlap,
+                "final_overlap_fraction": final_overlap,
+                "temporal_leakage_free": final_overlap == 0.0,
+                "train_start_time": train_start,
+                "train_end_time": train_end,
+                "test_start_time": test_start,
+                "test_end_time": test_end,
+                "groups_disjoint": groups_disjoint,
+            }
+        )
+    return pd.DataFrame.from_records(rows, columns=_AUDIT_COLUMNS)
 
 
 def assert_no_temporal_leakage(
@@ -203,9 +384,7 @@ def assert_groups_disjoint(
     test_group_values = groups[test_idx]
     if pd.isna(train_group_values).any() or pd.isna(test_group_values).any():
         raise ValueError("groups contains missing values in train or test indices.")
-    train_groups = set(train_group_values.tolist())
-    test_groups = set(test_group_values.tolist())
-    overlap = train_groups & test_groups
+    overlap = _group_overlap_from_arrays(train_idx, test_idx, groups)
     if overlap:
         offender = next(iter(sorted(overlap, key=str)))
         raise GroupLeakageError(
@@ -219,14 +398,21 @@ def compute_overlap_fraction(
     test_idx: NDArrayAny,
     prediction_times: TimesLike,
     evaluation_times: TimesLike,
+    *,
+    purge_horizon: HorizonLike | None = None,
 ) -> float:
     """Return the fraction of training rows whose half-open label horizon
-    overlaps any test horizon.
+    overlaps any test horizon, optionally padded by ``purge_horizon``.
 
-    Unlike :func:`assert_no_temporal_leakage`, this never raises — it
-    returns ``0.0`` for clean splits and ``1.0`` when every training row
-    leaks. Useful for logging splitter health metrics or for debugging
-    a splitter that produces unexpected behavior.
+    Unlike :func:`assert_no_temporal_leakage`, this does not raise when it
+    finds leakage: it returns ``0.0`` for clean splits and ``1.0`` when every
+    training row leaks. Malformed indices, times, and horizons still raise
+    validation errors. Useful for logging splitter health metrics or for
+    debugging a splitter that produces unexpected behavior.
+
+    ``purge_horizon`` defaults to no padding. To compare this value with an
+    ``audit_splitter`` report's ``candidate_overlap_fraction``, pass the
+    audited splitter's configured ``purge_horizon`` explicitly.
 
     Examples:
         >>> import numpy as np
@@ -241,17 +427,17 @@ def compute_overlap_fraction(
         ... )
         1.0
     """
+    horizon = parse_horizon(purge_horizon) if purge_horizon is not None else pd.Timedelta(0)
     prediction_times = _coerce_1d(prediction_times, name="prediction_times")
     evaluation_times = _coerce_1d(evaluation_times, name="evaluation_times")
     validate_times(prediction_times, evaluation_times, require_monotonic=False)
     n_samples = len(prediction_times)
     train_idx = _validate_positional_indices("train_idx", train_idx, n_samples=n_samples)
     test_idx = _validate_positional_indices("test_idx", test_idx, n_samples=n_samples)
-    if len(train_idx) == 0 or len(test_idx) == 0:
-        return 0.0
-    train_pred = prediction_times[train_idx]
-    train_eval = evaluation_times[train_idx]
-    test_starts = prediction_times[test_idx]
-    test_ends = evaluation_times[test_idx]
-    overlaps = overlaps_any_half_open_interval(train_pred, train_eval, test_starts, test_ends)
-    return float(overlaps.mean())
+    return _overlap_fraction_from_arrays(
+        train_idx,
+        test_idx,
+        prediction_times,
+        evaluation_times,
+        horizon,
+    )

--- a/src/purgedcv/diagnostics.py
+++ b/src/purgedcv/diagnostics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pandas as pd
 
 from purgedcv._base import BaseTemporalSplitter
@@ -44,17 +45,20 @@ _AUDIT_COLUMNS = (
     "candidate_train_size",
     "final_train_size",
     "test_size",
+    "train_nonempty",
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
-    "rows_removed_by_window",
+    "rows_removed_by_finalization",
     "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
     "temporal_leakage_free",
-    "train_start_time",
-    "train_end_time",
-    "test_start_time",
-    "test_end_time",
+    "train_block_count",
+    "test_block_count",
+    "train_time_envelope_start",
+    "train_time_envelope_end",
+    "test_time_envelope_start",
+    "test_time_envelope_end",
     "groups_disjoint",
 )
 
@@ -77,25 +81,42 @@ def _overlap_fraction_from_arrays(
     return float(overlaps.mean())
 
 
-def _time_bounds(
+def _nat_like(values: NDArrayAny) -> object:
+    """Return a NaT scalar preserving a temporal array's dtype family/unit."""
+    if not (
+        np.issubdtype(values.dtype, np.datetime64) or np.issubdtype(values.dtype, np.timedelta64)
+    ):
+        raise TypeError(f"expected a temporal dtype, got {values.dtype}.")
+    nat: object = np.asarray("NaT", dtype=values.dtype)[()]
+    return nat
+
+
+def _time_envelope(
     indices: NDArrayAny,
     prediction_times: NDArrayAny,
     evaluation_times: NDArrayAny,
 ) -> tuple[object, object]:
-    """Return the label-horizon envelope for a positional index array."""
+    """Return the outer label-horizon envelope for positional indices."""
     if len(indices) == 0:
-        return pd.NaT, pd.NaT
+        return _nat_like(prediction_times), _nat_like(evaluation_times)
     return prediction_times[indices].min(), evaluation_times[indices].max()
 
 
-def _group_overlap_from_arrays(
-    train_idx: NDArrayAny,
-    test_idx: NDArrayAny,
-    groups: NDArrayAny,
+def _contiguous_block_count(indices: NDArrayAny) -> int:
+    """Count contiguous positional-index runs, independent of input order."""
+    if len(indices) == 0:
+        return 0
+    ordered = np.sort(indices)
+    return int(1 + np.count_nonzero(np.diff(ordered) > 1))
+
+
+def _group_overlap_from_values(
+    train_group_values: NDArrayAny,
+    test_group_values: NDArrayAny,
 ) -> set[Any]:
     """Return group identifiers shared by train and test arrays."""
-    train_groups = set(groups[train_idx].tolist())
-    test_groups = set(groups[test_idx].tolist())
+    train_groups = set(train_group_values.tolist())
+    test_groups = set(test_group_values.tolist())
     return train_groups & test_groups
 
 
@@ -118,25 +139,43 @@ def audit_splitter(
     The report consumes the same candidate → purge → embargo → final pipeline
     as :meth:`BaseTemporalSplitter.split`; purge and embargo counts therefore
     come from the actual intermediate index arrays rather than being inferred
-    from the final split. Sliding walk-forward truncation is reported
-    separately as ``rows_removed_by_window``. If a custom finalization hook
-    introduces indices, ``rows_added_by_finalization`` reports them rather
-    than allowing the removal count to become negative or conceal a swap.
+    from the final split. Sliding walk-forward truncation is implemented by
+    the finalization stage and therefore appears in
+    ``rows_removed_by_finalization``. If a custom finalization hook introduces
+    indices, ``rows_added_by_finalization`` reports them separately.
 
     ``candidate_overlap_fraction`` is the fraction of candidate training rows
     whose label horizons overlap the test horizons after applying the
-    splitter's ``purge_horizon`` padding. To reproduce it with
-    :func:`compute_overlap_fraction`, pass the same ``purge_horizon``
-    explicitly. ``final_overlap_fraction`` repeats the measure on the final
-    training rows and should be zero for a clean splitter.
+    splitter's ``purge_horizon`` padding. For non-empty candidates it equals
+    ``rows_removed_by_purge / candidate_train_size``; empty candidates report
+    zero. :func:`compute_overlap_fraction` reproduces it only when given the
+    same pre-purge candidate indices and purge horizon — indices returned by
+    ``cv.split()`` are already final. ``final_overlap_fraction`` repeats the
+    measure on final training rows and should be zero for a clean splitter.
 
     For the built-in splitters, ``temporal_leakage_free`` is structurally
     expected to be ``True``: purge removes overlaps and later stages only
     remove rows. The column is primarily a regression guard for custom
     :class:`BaseTemporalSplitter` subclasses whose finalization hook could
     accidentally reintroduce indices; it is not an independent validation
-    algorithm. Leakage and group overlap are reported as values instead of
-    raising; malformed inputs and splitter configuration errors still raise.
+    algorithm. For an empty final train set it is vacuously ``True``; inspect
+    ``train_nonempty`` before treating a fold as usable. Leakage and group
+    overlap are reported as values instead of raising; malformed inputs and
+    splitter configuration errors still raise.
+
+    Time columns are outer envelopes, not continuous windows. CPCV and
+    interleaved group folds can contain several disjoint positional blocks, so
+    train and test envelopes may overlap even when
+    ``final_overlap_fraction == 0``. ``train_block_count`` and
+    ``test_block_count`` expose that layout; the counts refer to contiguous
+    runs of positional indices.
+
+    The audit requires the inherited :meth:`BaseTemporalSplitter.split`
+    implementation. A subclass overriding ``split()`` is rejected because its
+    returned folds may diverge from the auditable candidate → purge → embargo
+    → finalization pipeline. Custom subclasses should use
+    ``_iter_test_indices``, ``_candidate_train_idx``, and
+    ``_finalize_train_idx`` instead.
 
     Args:
         cv: A :class:`BaseTemporalSplitter` instance with times already bound.
@@ -145,14 +184,15 @@ def audit_splitter(
 
     Returns:
         A DataFrame with one row per fold. Columns contain the zero-based fold
-        number; candidate, final, and test sizes; rows removed at the purge,
-        embargo, and splitter-specific window stages; indices added by custom
-        finalization; candidate and final temporal-overlap fractions; final
-        train and test label-horizon bounds; and ``groups_disjoint`` (``None``
-        when no groups are bound).
+        number; candidate, final, and test sizes; train non-emptiness; rows
+        removed at purge, embargo, and finalization; indices added by custom
+        finalization; candidate and final temporal-overlap fractions;
+        contiguous block counts; outer train/test time envelopes; and
+        ``groups_disjoint`` (``None`` when no groups are bound).
 
     Raises:
-        TypeError: if ``cv`` is not a :class:`BaseTemporalSplitter`.
+        TypeError: if ``cv`` is not a :class:`BaseTemporalSplitter` or its
+            class overrides :meth:`BaseTemporalSplitter.split`.
         ValueError: if ``X`` has the wrong length or the splitter cannot form
             its configured folds.
 
@@ -176,6 +216,12 @@ def audit_splitter(
         raise TypeError(
             f"cv must be a purgedcv BaseTemporalSplitter instance, got {type(cv).__name__}."
         )
+    if type(cv).split is not BaseTemporalSplitter.split:
+        raise TypeError(
+            "audit_splitter cannot audit a subclass that overrides split(); "
+            "customize _iter_test_indices, _candidate_train_idx, or "
+            "_finalize_train_idx while inheriting BaseTemporalSplitter.split."
+        )
 
     rows: list[dict[str, object]] = []
     prediction_times = cv._prediction_times
@@ -196,16 +242,18 @@ def audit_splitter(
             evaluation_times,
             cv.purge_horizon,
         )
-        train_start, train_end = _time_bounds(
+        train_envelope_start, train_envelope_end = _time_envelope(
             stages.final_train_idx, prediction_times, evaluation_times
         )
-        test_start, test_end = _time_bounds(stages.test_idx, prediction_times, evaluation_times)
+        test_envelope_start, test_envelope_end = _time_envelope(
+            stages.test_idx, prediction_times, evaluation_times
+        )
         groups_disjoint: bool | None = None
         if groups is not None:
-            groups_disjoint = not _group_overlap_from_arrays(
-                stages.final_train_idx, stages.test_idx, groups
-            )
-        removed_by_window, added_by_finalization = _index_membership_changes(
+            train_group_values = groups[stages.final_train_idx]
+            test_group_values = groups[stages.test_idx]
+            groups_disjoint = not _group_overlap_from_values(train_group_values, test_group_values)
+        removed_by_finalization, added_by_finalization = _index_membership_changes(
             stages.embargoed_train_idx, stages.final_train_idx
         )
 
@@ -215,19 +263,22 @@ def audit_splitter(
                 "candidate_train_size": len(stages.candidate_train_idx),
                 "final_train_size": len(stages.final_train_idx),
                 "test_size": len(stages.test_idx),
+                "train_nonempty": len(stages.final_train_idx) > 0,
                 "rows_removed_by_purge": len(stages.candidate_train_idx)
                 - len(stages.purged_train_idx),
                 "rows_removed_by_embargo": len(stages.purged_train_idx)
                 - len(stages.embargoed_train_idx),
-                "rows_removed_by_window": removed_by_window,
+                "rows_removed_by_finalization": removed_by_finalization,
                 "rows_added_by_finalization": added_by_finalization,
                 "candidate_overlap_fraction": candidate_overlap,
                 "final_overlap_fraction": final_overlap,
                 "temporal_leakage_free": final_overlap == 0.0,
-                "train_start_time": train_start,
-                "train_end_time": train_end,
-                "test_start_time": test_start,
-                "test_end_time": test_end,
+                "train_block_count": _contiguous_block_count(stages.final_train_idx),
+                "test_block_count": _contiguous_block_count(stages.test_idx),
+                "train_time_envelope_start": train_envelope_start,
+                "train_time_envelope_end": train_envelope_end,
+                "test_time_envelope_start": test_envelope_start,
+                "test_time_envelope_end": test_envelope_end,
                 "groups_disjoint": groups_disjoint,
             }
         )
@@ -401,7 +452,7 @@ def assert_groups_disjoint(
     test_group_values = groups[test_idx]
     if pd.isna(train_group_values).any() or pd.isna(test_group_values).any():
         raise ValueError("groups contains missing values in train or test indices.")
-    overlap = _group_overlap_from_arrays(train_idx, test_idx, groups)
+    overlap = _group_overlap_from_values(train_group_values, test_group_values)
     if overlap:
         offender = next(iter(sorted(overlap, key=str)))
         raise GroupLeakageError(
@@ -427,9 +478,10 @@ def compute_overlap_fraction(
     validation errors. Useful for logging splitter health metrics or for
     debugging a splitter that produces unexpected behavior.
 
-    ``purge_horizon`` defaults to no padding. To compare this value with an
-    ``audit_splitter`` report's ``candidate_overlap_fraction``, pass the
-    audited splitter's configured ``purge_horizon`` explicitly.
+    ``purge_horizon`` defaults to no padding. Reproducing an
+    ``audit_splitter`` report's ``candidate_overlap_fraction`` also requires
+    its pre-purge candidate indices; the indices yielded by ``cv.split()`` are
+    final and instead reproduce ``final_overlap_fraction``.
 
     Examples:
         >>> import numpy as np

--- a/tests/e2e/test_e2e_audit_splitter.py
+++ b/tests/e2e/test_e2e_audit_splitter.py
@@ -47,8 +47,8 @@ def test_user_story_preflight_fold_removal_report() -> None:
 
 
 @pytest.mark.e2e
-def test_user_story_sliding_window_is_not_mislabeled_as_leakage_control() -> None:
-    """Window truncation has its own count in a rolling deployment setup."""
+def test_user_story_sliding_window_is_a_finalization_removal() -> None:
+    """Window truncation appears at the finalization stage, not as purge."""
     pred = pd.date_range("2024-01-01", periods=20, freq="D")
     evalu = pred + pd.Timedelta(days=1)
     cv = WalkForwardSplit(
@@ -66,7 +66,7 @@ def test_user_story_sliding_window_is_not_mislabeled_as_leakage_control() -> Non
     assert report["final_train_size"].tolist() == [5, 5, 5]
     assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
     assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
-    assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+    assert report["rows_removed_by_finalization"].tolist() == [8, 10, 12]
     assert report["rows_added_by_finalization"].tolist() == [0, 0, 0]
 
 
@@ -90,6 +90,9 @@ def test_subprocess_fresh_interpreter_can_audit_splitter() -> None:
         assert report.shape[0] == 3
         assert "candidate_overlap_fraction" in report.columns
         assert "final_overlap_fraction" in report.columns
+        assert "train_nonempty" in report.columns
+        assert "test_block_count" in report.columns
+        assert "rows_removed_by_finalization" in report.columns
         assert "rows_added_by_finalization" in report.columns
         assert report["final_overlap_fraction"].eq(0.0).all()
         print("OK")

--- a/tests/e2e/test_e2e_audit_splitter.py
+++ b/tests/e2e/test_e2e_audit_splitter.py
@@ -1,0 +1,102 @@
+"""End-to-end tests for the public ``audit_splitter`` entry point.
+
+User stories:
+- A researcher wants to inspect how many observations each fold loses to
+  purge and embargo before committing compute to a large model search.
+- A walk-forward user wants window truncation reported separately from
+  leakage controls so an unexpectedly small train set is explainable.
+- An installed-package consumer imports the helper from a fresh interpreter
+  and receives the same stable DataFrame schema as in-process callers.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from purgedcv import PurgedKFold, WalkForwardSplit, audit_splitter
+
+
+@pytest.mark.e2e
+def test_user_story_preflight_fold_removal_report() -> None:
+    """A model-search preflight explains purge and embargo losses per fold."""
+    pred = pd.date_range("2024-01-01", periods=20, freq="D")
+    evalu = pred + pd.Timedelta(days=1)
+    cv = PurgedKFold(
+        4,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="1D",
+        embargo_observations=2,
+    )
+
+    report = audit_splitter(cv, np.zeros((20, 3)))
+
+    assert len(report) == 4
+    assert report.loc[0, "candidate_train_size"] == 15
+    assert report.loc[0, "rows_removed_by_purge"] == 1
+    assert report.loc[0, "rows_removed_by_embargo"] == 1
+    assert report.loc[0, "final_train_size"] == 13
+    assert report.loc[0, "candidate_overlap_fraction"] == pytest.approx(1 / 15)
+    assert report["final_overlap_fraction"].eq(0.0).all()
+
+
+@pytest.mark.e2e
+def test_user_story_sliding_window_is_not_mislabeled_as_leakage_control() -> None:
+    """Window truncation has its own count in a rolling deployment setup."""
+    pred = pd.date_range("2024-01-01", periods=20, freq="D")
+    evalu = pred + pd.Timedelta(days=1)
+    cv = WalkForwardSplit(
+        3,
+        2,
+        train_size=5,
+        window="sliding",
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="1D",
+    )
+
+    report = audit_splitter(cv, np.zeros((20, 1)))
+
+    assert report["final_train_size"].tolist() == [5, 5, 5]
+    assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
+    assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
+    assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+
+
+@pytest.mark.e2e
+def test_subprocess_fresh_interpreter_can_audit_splitter() -> None:
+    snippet = textwrap.dedent("""\
+        import numpy as np
+        import pandas as pd
+        from purgedcv import PurgedKFold, audit_splitter, diagnostics
+
+        pred = pd.date_range("2024-01-01", periods=12, freq="D")
+        evalu = pred + pd.Timedelta(days=1)
+        cv = PurgedKFold(
+            3,
+            prediction_times=pred,
+            evaluation_times=evalu,
+            purge_horizon="1D",
+        )
+        report = audit_splitter(cv, np.zeros((12, 1)))
+        assert diagnostics.audit_splitter is audit_splitter
+        assert report.shape[0] == 3
+        assert "candidate_overlap_fraction" in report.columns
+        assert "final_overlap_fraction" in report.columns
+        assert report["final_overlap_fraction"].eq(0.0).all()
+        print("OK")
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "OK"
+    assert result.stderr == ""

--- a/tests/e2e/test_e2e_audit_splitter.py
+++ b/tests/e2e/test_e2e_audit_splitter.py
@@ -67,6 +67,7 @@ def test_user_story_sliding_window_is_not_mislabeled_as_leakage_control() -> Non
     assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
     assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
     assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+    assert report["rows_added_by_finalization"].tolist() == [0, 0, 0]
 
 
 @pytest.mark.e2e
@@ -89,6 +90,7 @@ def test_subprocess_fresh_interpreter_can_audit_splitter() -> None:
         assert report.shape[0] == 3
         assert "candidate_overlap_fraction" in report.columns
         assert "final_overlap_fraction" in report.columns
+        assert "rows_added_by_finalization" in report.columns
         assert report["final_overlap_fraction"].eq(0.0).all()
         print("OK")
         """)

--- a/tests/test_audit_splitter.py
+++ b/tests/test_audit_splitter.py
@@ -25,6 +25,7 @@ EXPECTED_COLUMNS = [
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
     "rows_removed_by_window",
+    "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
     "temporal_leakage_free",
@@ -60,6 +61,7 @@ def test_audit_reports_real_purge_and_embargo_stages() -> None:
     assert first["rows_removed_by_purge"] == 1
     assert first["rows_removed_by_embargo"] == 1
     assert first["rows_removed_by_window"] == 0
+    assert first["rows_added_by_finalization"] == 0
     assert first["final_train_size"] == 13
     assert first["candidate_overlap_fraction"] == pytest.approx(1 / 15)
     assert first["final_overlap_fraction"] == 0.0
@@ -75,6 +77,7 @@ def test_audit_reports_real_purge_and_embargo_stages() -> None:
         + report["rows_removed_by_purge"]
         + report["rows_removed_by_embargo"]
         + report["rows_removed_by_window"]
+        - report["rows_added_by_finalization"]
     )
     pd.testing.assert_series_equal(
         accounted,
@@ -122,6 +125,7 @@ def test_sliding_window_removals_are_reported_separately() -> None:
     assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
     assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
     assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+    assert report["rows_added_by_finalization"].tolist() == [0, 0, 0]
 
 
 def test_group_disjointness_is_reported_when_groups_are_bound() -> None:
@@ -161,6 +165,15 @@ class _ReintroducingSplitter(_GroupLeakingSplitter):
         return np.append(train_idx, test_idx[0])
 
 
+class _ReplacingSplitter(_GroupLeakingSplitter):
+    def _finalize_train_idx(
+        self,
+        train_idx: NDArrayAny,
+        test_idx: NDArrayAny,
+    ) -> NDArrayAny:
+        return np.append(train_idx[1:], test_idx[0])
+
+
 def test_group_leakage_is_reported_without_raising() -> None:
     pred, evalu = _times(n=6)
     cv = _GroupLeakingSplitter(
@@ -187,6 +200,23 @@ def test_temporal_status_catches_custom_finalizer_reintroducing_test_row() -> No
     report = audit_splitter(cv, np.zeros((6, 1)))
 
     assert report.loc[0, "final_overlap_fraction"] != 0.0
+    assert not bool(report.loc[0, "temporal_leakage_free"])
+    assert report.loc[0, "rows_removed_by_window"] == 0
+    assert report.loc[0, "rows_added_by_finalization"] == 1
+
+
+def test_finalizer_replacement_reports_one_removal_and_one_addition() -> None:
+    pred, evalu = _times(n=6)
+    cv = _ReplacingSplitter(
+        prediction_times=pred,
+        evaluation_times=evalu,
+    )
+
+    report = audit_splitter(cv, np.zeros((6, 1)))
+
+    assert report.loc[0, "final_train_size"] == 5
+    assert report.loc[0, "rows_removed_by_window"] == 1
+    assert report.loc[0, "rows_added_by_finalization"] == 1
     assert not bool(report.loc[0, "temporal_leakage_free"])
 
 

--- a/tests/test_audit_splitter.py
+++ b/tests/test_audit_splitter.py
@@ -1,0 +1,217 @@
+"""Unit tests for the per-fold splitter audit report (A6)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from purgedcv import (
+    CombinatorialPurgedCV,
+    PurgedGroupKFold,
+    PurgedKFold,
+    WalkForwardSplit,
+    audit_splitter,
+)
+from purgedcv._base import BaseTemporalSplitter
+from purgedcv._typing import NDArrayAny
+from purgedcv.exceptions import GroupLeakageError
+
+EXPECTED_COLUMNS = [
+    "fold",
+    "candidate_train_size",
+    "final_train_size",
+    "test_size",
+    "rows_removed_by_purge",
+    "rows_removed_by_embargo",
+    "rows_removed_by_window",
+    "candidate_overlap_fraction",
+    "final_overlap_fraction",
+    "temporal_leakage_free",
+    "train_start_time",
+    "train_end_time",
+    "test_start_time",
+    "test_end_time",
+    "groups_disjoint",
+]
+
+
+def _times(n: int = 20) -> tuple[pd.DatetimeIndex, pd.DatetimeIndex]:
+    prediction_times = pd.date_range("2024-01-01", periods=n, freq="D")
+    return prediction_times, prediction_times + pd.Timedelta(days=1)
+
+
+def test_audit_reports_real_purge_and_embargo_stages() -> None:
+    pred, evalu = _times()
+    cv = PurgedKFold(
+        4,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="1D",
+        embargo_observations=2,
+    )
+
+    report = audit_splitter(cv, np.zeros((20, 1)))
+
+    assert list(report.columns) == EXPECTED_COLUMNS
+    assert len(report) == cv.get_n_splits()
+    first = report.iloc[0]
+    assert first["candidate_train_size"] == 15
+    assert first["rows_removed_by_purge"] == 1
+    assert first["rows_removed_by_embargo"] == 1
+    assert first["rows_removed_by_window"] == 0
+    assert first["final_train_size"] == 13
+    assert first["candidate_overlap_fraction"] == pytest.approx(1 / 15)
+    assert first["final_overlap_fraction"] == 0.0
+    assert bool(first["temporal_leakage_free"])
+    assert first["train_start_time"] == pd.Timestamp("2024-01-08")
+    assert first["train_end_time"] == pd.Timestamp("2024-01-21")
+    assert first["test_start_time"] == pd.Timestamp("2024-01-01")
+    assert first["test_end_time"] == pd.Timestamp("2024-01-06")
+    assert first["groups_disjoint"] is None
+
+    accounted = (
+        report["final_train_size"]
+        + report["rows_removed_by_purge"]
+        + report["rows_removed_by_embargo"]
+        + report["rows_removed_by_window"]
+    )
+    pd.testing.assert_series_equal(
+        accounted,
+        report["candidate_train_size"],
+        check_names=False,
+    )
+
+
+def test_audit_matches_final_indices_yielded_by_split() -> None:
+    pred, evalu = _times(n=24)
+    cv = CombinatorialPurgedCV(
+        4,
+        2,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="1D",
+        embargo_fraction=0.1,
+    )
+    X = np.zeros((24, 2))  # noqa: N806
+
+    report = audit_splitter(cv, X)
+    folds = list(cv.split(X))
+
+    assert len(report) == len(folds) == cv.get_n_splits()
+    assert report["final_train_size"].tolist() == [len(train) for train, _ in folds]
+    assert report["test_size"].tolist() == [len(test) for _, test in folds]
+    assert report["final_overlap_fraction"].eq(0.0).all()
+
+
+def test_sliding_window_removals_are_reported_separately() -> None:
+    pred, evalu = _times()
+    cv = WalkForwardSplit(
+        3,
+        2,
+        train_size=5,
+        window="sliding",
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="1D",
+    )
+
+    report = audit_splitter(cv, np.zeros((20, 1)))
+
+    assert report["final_train_size"].tolist() == [5, 5, 5]
+    assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
+    assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
+    assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+
+
+def test_group_disjointness_is_reported_when_groups_are_bound() -> None:
+    pred, evalu = _times(n=12)
+    groups = np.repeat(["a", "b", "c", "d"], 3)
+    cv = PurgedGroupKFold(
+        2,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        groups=groups,
+    )
+
+    report = audit_splitter(cv, np.zeros((12, 1)))
+
+    assert report["groups_disjoint"].eq(True).all()
+
+
+class _GroupLeakingSplitter(BaseTemporalSplitter):
+    def _iter_test_indices(self, n_samples: int) -> list[NDArrayAny]:
+        return [np.array([0], dtype=np.int64)]
+
+    def get_n_splits(
+        self,
+        X: object = None,  # noqa: N803
+        y: object = None,
+        groups: object = None,
+    ) -> int:
+        return 1
+
+
+class _ReintroducingSplitter(_GroupLeakingSplitter):
+    def _finalize_train_idx(
+        self,
+        train_idx: NDArrayAny,
+        test_idx: NDArrayAny,
+    ) -> NDArrayAny:
+        return np.append(train_idx, test_idx[0])
+
+
+def test_group_leakage_is_reported_without_raising() -> None:
+    pred, evalu = _times(n=6)
+    cv = _GroupLeakingSplitter(
+        prediction_times=pred,
+        evaluation_times=evalu,
+        groups=np.repeat("same-group", 6),
+    )
+    X = np.zeros((6, 1))  # noqa: N806
+
+    report = audit_splitter(cv, X)
+
+    assert not bool(report.loc[0, "groups_disjoint"])
+    with pytest.raises(GroupLeakageError):
+        list(cv.split(X))
+
+
+def test_temporal_status_catches_custom_finalizer_reintroducing_test_row() -> None:
+    pred, evalu = _times(n=6)
+    cv = _ReintroducingSplitter(
+        prediction_times=pred,
+        evaluation_times=evalu,
+    )
+
+    report = audit_splitter(cv, np.zeros((6, 1)))
+
+    assert report.loc[0, "final_overlap_fraction"] != 0.0
+    assert not bool(report.loc[0, "temporal_leakage_free"])
+
+
+def test_empty_final_train_has_missing_bounds() -> None:
+    pred, evalu = _times(n=4)
+    cv = PurgedKFold(
+        2,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="100D",
+    )
+
+    report = audit_splitter(cv, np.zeros((4, 1)))
+
+    assert report["final_train_size"].eq(0).all()
+    assert report["train_start_time"].isna().all()
+    assert report["train_end_time"].isna().all()
+    assert report["final_overlap_fraction"].eq(0.0).all()
+
+
+def test_rejects_non_temporal_splitter_and_wrong_x_length() -> None:
+    with pytest.raises(TypeError, match="BaseTemporalSplitter"):
+        audit_splitter(object(), np.zeros((3, 1)))  # type: ignore[arg-type]
+
+    pred, evalu = _times(n=6)
+    cv = PurgedKFold(2, prediction_times=pred, evaluation_times=evalu)
+    with pytest.raises(ValueError, match="X length"):
+        audit_splitter(cv, np.zeros((5, 1)))

--- a/tests/test_audit_splitter.py
+++ b/tests/test_audit_splitter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -22,17 +24,20 @@ EXPECTED_COLUMNS = [
     "candidate_train_size",
     "final_train_size",
     "test_size",
+    "train_nonempty",
     "rows_removed_by_purge",
     "rows_removed_by_embargo",
-    "rows_removed_by_window",
+    "rows_removed_by_finalization",
     "rows_added_by_finalization",
     "candidate_overlap_fraction",
     "final_overlap_fraction",
     "temporal_leakage_free",
-    "train_start_time",
-    "train_end_time",
-    "test_start_time",
-    "test_end_time",
+    "train_block_count",
+    "test_block_count",
+    "train_time_envelope_start",
+    "train_time_envelope_end",
+    "test_time_envelope_start",
+    "test_time_envelope_end",
     "groups_disjoint",
 ]
 
@@ -60,23 +65,26 @@ def test_audit_reports_real_purge_and_embargo_stages() -> None:
     assert first["candidate_train_size"] == 15
     assert first["rows_removed_by_purge"] == 1
     assert first["rows_removed_by_embargo"] == 1
-    assert first["rows_removed_by_window"] == 0
+    assert first["rows_removed_by_finalization"] == 0
     assert first["rows_added_by_finalization"] == 0
     assert first["final_train_size"] == 13
+    assert bool(first["train_nonempty"])
     assert first["candidate_overlap_fraction"] == pytest.approx(1 / 15)
     assert first["final_overlap_fraction"] == 0.0
     assert bool(first["temporal_leakage_free"])
-    assert first["train_start_time"] == pd.Timestamp("2024-01-08")
-    assert first["train_end_time"] == pd.Timestamp("2024-01-21")
-    assert first["test_start_time"] == pd.Timestamp("2024-01-01")
-    assert first["test_end_time"] == pd.Timestamp("2024-01-06")
+    assert first["train_block_count"] == 1
+    assert first["test_block_count"] == 1
+    assert first["train_time_envelope_start"] == pd.Timestamp("2024-01-08")
+    assert first["train_time_envelope_end"] == pd.Timestamp("2024-01-21")
+    assert first["test_time_envelope_start"] == pd.Timestamp("2024-01-01")
+    assert first["test_time_envelope_end"] == pd.Timestamp("2024-01-06")
     assert first["groups_disjoint"] is None
 
     accounted = (
         report["final_train_size"]
         + report["rows_removed_by_purge"]
         + report["rows_removed_by_embargo"]
-        + report["rows_removed_by_window"]
+        + report["rows_removed_by_finalization"]
         - report["rows_added_by_finalization"]
     )
     pd.testing.assert_series_equal(
@@ -107,7 +115,7 @@ def test_audit_matches_final_indices_yielded_by_split() -> None:
     assert report["final_overlap_fraction"].eq(0.0).all()
 
 
-def test_sliding_window_removals_are_reported_separately() -> None:
+def test_sliding_window_removals_are_reported_as_finalization() -> None:
     pred, evalu = _times()
     cv = WalkForwardSplit(
         3,
@@ -124,7 +132,7 @@ def test_sliding_window_removals_are_reported_separately() -> None:
     assert report["final_train_size"].tolist() == [5, 5, 5]
     assert report["rows_removed_by_purge"].tolist() == [1, 1, 1]
     assert report["rows_removed_by_embargo"].tolist() == [0, 0, 0]
-    assert report["rows_removed_by_window"].tolist() == [8, 10, 12]
+    assert report["rows_removed_by_finalization"].tolist() == [8, 10, 12]
     assert report["rows_added_by_finalization"].tolist() == [0, 0, 0]
 
 
@@ -174,6 +182,26 @@ class _ReplacingSplitter(_GroupLeakingSplitter):
         return np.append(train_idx[1:], test_idx[0])
 
 
+class _DuplicatingSplitter(_GroupLeakingSplitter):
+    def _finalize_train_idx(
+        self,
+        train_idx: NDArrayAny,
+        test_idx: NDArrayAny,
+    ) -> NDArrayAny:
+        return np.concatenate([train_idx, train_idx[:2]])
+
+
+class _SplitOverride(_GroupLeakingSplitter):
+    def split(
+        self,
+        X: NDArrayAny | pd.DataFrame,  # noqa: N803
+        y: object = None,
+        groups: object = None,
+    ) -> Iterator[tuple[NDArrayAny, NDArrayAny]]:
+        for train_idx, test_idx in super().split(X, y=y, groups=groups):
+            yield np.append(train_idx, test_idx[0]), test_idx
+
+
 def test_group_leakage_is_reported_without_raising() -> None:
     pred, evalu = _times(n=6)
     cv = _GroupLeakingSplitter(
@@ -201,7 +229,7 @@ def test_temporal_status_catches_custom_finalizer_reintroducing_test_row() -> No
 
     assert report.loc[0, "final_overlap_fraction"] != 0.0
     assert not bool(report.loc[0, "temporal_leakage_free"])
-    assert report.loc[0, "rows_removed_by_window"] == 0
+    assert report.loc[0, "rows_removed_by_finalization"] == 0
     assert report.loc[0, "rows_added_by_finalization"] == 1
 
 
@@ -215,9 +243,36 @@ def test_finalizer_replacement_reports_one_removal_and_one_addition() -> None:
     report = audit_splitter(cv, np.zeros((6, 1)))
 
     assert report.loc[0, "final_train_size"] == 5
-    assert report.loc[0, "rows_removed_by_window"] == 1
+    assert report.loc[0, "rows_removed_by_finalization"] == 1
     assert report.loc[0, "rows_added_by_finalization"] == 1
     assert not bool(report.loc[0, "temporal_leakage_free"])
+
+
+def test_rejects_duplicate_indices_from_custom_finalizer() -> None:
+    pred, evalu = _times(n=6)
+    cv = _DuplicatingSplitter(
+        prediction_times=pred,
+        evaluation_times=evalu,
+    )
+
+    with pytest.raises(ValueError, match=r"final_train_idx.*duplicate"):
+        audit_splitter(cv, np.zeros((6, 1)))
+    with pytest.raises(ValueError, match=r"final_train_idx.*duplicate"):
+        list(cv.split(np.zeros((6, 1))))
+
+
+def test_rejects_subclass_that_overrides_split() -> None:
+    pred, evalu = _times(n=8)
+    cv = _SplitOverride(
+        prediction_times=pred,
+        evaluation_times=evalu,
+    )
+    X = np.zeros((8, 1))  # noqa: N806
+
+    real_train, real_test = next(cv.split(X))
+    assert real_test[0] in real_train
+    with pytest.raises(TypeError, match=r"overrides split\(\)"):
+        audit_splitter(cv, X)
 
 
 def test_empty_final_train_has_missing_bounds() -> None:
@@ -232,9 +287,45 @@ def test_empty_final_train_has_missing_bounds() -> None:
     report = audit_splitter(cv, np.zeros((4, 1)))
 
     assert report["final_train_size"].eq(0).all()
-    assert report["train_start_time"].isna().all()
-    assert report["train_end_time"].isna().all()
+    assert report["train_nonempty"].eq(False).all()
+    assert report["train_time_envelope_start"].isna().all()
+    assert report["train_time_envelope_end"].isna().all()
     assert report["final_overlap_fraction"].eq(0.0).all()
+    assert report["temporal_leakage_free"].eq(True).all()
+
+
+def test_timedelta_empty_envelope_preserves_timedelta_dtype() -> None:
+    pred = pd.timedelta_range(start="0D", periods=4, freq="D")
+    evalu = pred + pd.Timedelta(days=1)
+    cv = PurgedKFold(
+        2,
+        prediction_times=pred,
+        evaluation_times=evalu,
+        purge_horizon="100D",
+    )
+
+    report = audit_splitter(cv, np.zeros((4, 1)))
+
+    assert str(report["train_time_envelope_start"].dtype).startswith("timedelta64")
+    assert not (report["train_time_envelope_start"] < pd.Timedelta(days=1)).any()
+
+
+def test_cpcv_envelopes_expose_disjoint_block_counts() -> None:
+    pred, evalu = _times(n=24)
+    cv = CombinatorialPurgedCV(
+        4,
+        2,
+        prediction_times=pred,
+        evaluation_times=evalu,
+    )
+
+    report = audit_splitter(cv, np.zeros((24, 1)))
+    row = report.loc[report["test_block_count"].eq(2)].iloc[0]
+
+    assert row["train_block_count"] == 2
+    assert row["train_time_envelope_start"] < row["test_time_envelope_end"]
+    assert row["test_time_envelope_start"] < row["train_time_envelope_end"]
+    assert row["final_overlap_fraction"] == 0.0
 
 
 def test_rejects_non_temporal_splitter_and_wrong_x_length() -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -336,6 +336,22 @@ class TestComputeOverlapFraction:
         test_idx = np.array([0, 1, 2, 9, 10, 11])
         assert compute_overlap_fraction(train_idx, test_idx, pred, evalu) == 0.0
 
+    def test_purge_horizon_padding_is_counted(self) -> None:
+        pred, evalu = _make_horizon_dataset(horizon_days=1)
+        train_idx = np.array([9])
+        test_idx = np.arange(10, 15)
+        assert compute_overlap_fraction(train_idx, test_idx, pred, evalu) == 0.0
+        assert (
+            compute_overlap_fraction(
+                train_idx,
+                test_idx,
+                pred,
+                evalu,
+                purge_horizon="1D",
+            )
+            == 1.0
+        )
+
 
 def test_compute_overlap_fraction_numpy_matches_pandas() -> None:
     from purgedcv.diagnostics import compute_overlap_fraction

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -23,6 +23,7 @@ EXPECTED_TOP_LEVEL: frozenset[str] = frozenset(
     {
         "__version__",
         "apply_embargo",
+        "audit_splitter",
         "ArrayLike1D",
         "BaseTemporalSplitter",
         "CombinatorialPurgedCV",
@@ -58,6 +59,7 @@ EXPECTED_DIAGNOSTICS: frozenset[str] = frozenset(
         "assert_embargo_respected",
         "assert_groups_disjoint",
         "assert_no_temporal_leakage",
+        "audit_splitter",
         "compute_overlap_fraction",
     }
 )


### PR DESCRIPTION
## What changes

Adds a public `audit_splitter(cv, X)` diagnostic that returns one DataFrame row
per fold, so a user can see how much data each fold actually loses before
committing compute to a model search. Implements ROADMAP item A6.

```python
from purgedcv import audit_splitter

report = audit_splitter(cv, features)
```

Columns: `fold`, `candidate_train_size`, `final_train_size`, `test_size`,
`rows_removed_by_purge`, `rows_removed_by_embargo`, `rows_removed_by_window`,
`candidate_overlap_fraction`, `final_overlap_fraction`, `temporal_leakage_free`,
`train_start_time`, `train_end_time`, `test_start_time`, `test_end_time`,
`groups_disjoint`.

The report never raises on leakage. It records leakage and group overlap as
values, which is the point: a monitoring loop can collect numbers across many
configurations without dying on the first bad split. Malformed inputs and
splitter misconfiguration still raise normally.

To make the per-stage counts honest rather than reconstructed, the fold
pipeline in `BaseTemporalSplitter` was pulled into a single generator,
`_iter_split_stages`, that yields the candidate, purged, embargoed, and final
index arrays for each fold. Both `split()` and `audit_splitter` consume it, so
the purge and embargo columns come from the real intermediate arrays instead of
being inferred by differencing the final indices.

`compute_overlap_fraction` gains an optional keyword-only `purge_horizon`
argument. It defaults to no padding, so existing calls return exactly what they
returned before.

## Checklist

- [x] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [x] `mypy src tests` is clean.
- [x] `pytest -q` is green locally (580 passed).
- [x] If this changes user-visible behaviour, there is a test under
      `tests/e2e/` that exercises it the way a user would.
- [x] If this touches user-facing documentation listed in
      `tools/prose_gate.py TARGETS`, the prose gate is FAIL-free.
- [x] If the docs site is affected, `mkdocs build --strict` is clean.
- [x] `CHANGELOG.md` has an entry under `Unreleased`, if the change is
      user-visible.

## Notes for the reviewer

**`WalkForwardSplit.split()` is gone.** Its only job was trimming the training
set to the most recent `train_size` rows for sliding windows, and it did that
after the base class had already yielded. That trimming now lives in a
`_finalize_train_idx` hook, so every splitter goes through one orchestration
path. The visible consequence is that group disjointness is now asserted on the
trimmed training set rather than the untrimmed one. That is unreachable in
practice: `WalkForwardSplit.__init__` does not accept `groups`, so no
walk-forward splitter can have groups bound. No behaviour changes for any
existing configuration.

**Window truncation is reported separately.** `rows_removed_by_window` keeps
sliding-window shrinkage distinct from purge and embargo, so a surprisingly
small training set is explainable rather than being blamed on leakage controls.
The four size columns reconcile exactly, which `test_audit_reports_real_purge_and_embargo_stages`
asserts as an identity.

**`temporal_leakage_free` is a regression guard, not an independent check.**
For the built-in splitters it is structurally always true, because `purge`
removes every overlapping row and the later stages only remove more. It earns
its place for custom `BaseTemporalSplitter` subclasses whose finalization hook
could reintroduce indices; `test_temporal_status_catches_custom_finalizer_reintroducing_test_row`
covers that case with a deliberately broken subclass. The docstring and the
quickstart both say this outright so nobody reads the column as validation.

**Overlap fractions use purge-horizon padding.** `candidate_overlap_fraction`
measures the candidate training rows against test horizons padded by the
splitter's configured `purge_horizon`, which matches what `purge()` itself does
and makes `final_overlap_fraction == 0` a real invariant rather than a
coincidence. Standalone `compute_overlap_fraction` still defaults to no padding,
so both docstrings spell out how to reproduce one number from the other.

**Import direction.** `diagnostics` now imports `BaseTemporalSplitter` at module
level for the public type and the shared pipeline. `_base` correspondingly
dropped its module-level import of `assert_groups_disjoint` and calls it through
a local import inside `split()`.

`audit_splitter` targets `BaseTemporalSplitter` on purpose and rejects anything
else with a `TypeError`. The row-level `assert_*` helpers and
`compute_overlap_fraction` stay framework-neutral and keep auditing sklearn,
tscv, or hand-rolled splits on equal terms. `docs/architecture.md` was updated
to state that split in the invariants section.
