### PR TITLE
feat: expose new public dataclasses and callback types for typed down…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Plan is listed under the published version it shipped in.
 
 ### Added
 
+- Public `PBOResult` and `DSRDiagnostics` result dataclasses, plus the
+  `HorizonLike`, `PathMetricFn`, and `PerformanceMetric` callback/input type
+  aliases, are now importable directly from `purgedcv` for typed downstream
+  code without reaching into private modules.
 - New public `audit_splitter(cv, X)` diagnostic returns one DataFrame row per
   fold with candidate and final train sizes, purge/embargo/finalization
   removal counts, indices added during custom finalization,

--- a/README.md
+++ b/README.md
@@ -35,10 +35,14 @@
 | `CombinatoriallySymmetricCV` | D5.4 | CSCV: symmetric IS/OOS folds, the PBO substrate |
 | `reconstruct_paths` | D6 | Assemble CPCV folds into backtest paths |
 | `path_metrics` | D6 | Per-path Sharpe / Calmar / drawdown / return table |
+| `PathMetricFn` | D6 | Callback type for custom per-path metrics |
 | `probabilistic_sharpe_ratio` | D7 | PSR: P(true SR > benchmark) |
 | `deflated_sharpe_ratio` | D7 | DSR: PSR corrected for multiple testing |
 | `deflated_sharpe_ratio_full` | D7 | DSR plus the intermediate deflation quantities |
+| `DSRDiagnostics` | D7 | Frozen result type returned by `deflated_sharpe_ratio_full` |
 | `probability_of_backtest_overfitting` | D7 | PBO via CSCV: how often in-sample selection overfits |
+| `PBOResult` | D7 | Frozen result type returned by PBO |
+| `PerformanceMetric` | D7 | Callback type for a custom PBO selection metric |
 | `min_track_record_length` | D7 | Minimum observations to establish SR |
 | `minimum_backtest_length` | D7 | MinBTL: backtest years below which a Sharpe is selection luck |
 | `effective_n_trials` | D7 | Independent-trial count for a correlated search, for DSR |

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,8 @@ contract.
 
 ::: purgedcv.ArrayLike1D
 
+::: purgedcv.HorizonLike
+
 ## Splitters
 
 ::: purgedcv.BaseTemporalSplitter
@@ -28,6 +30,8 @@ contract.
 ::: purgedcv.CombinatoriallySymmetricCV
 
 ## Backtest paths
+
+::: purgedcv.PathMetricFn
 
 ::: purgedcv.reconstruct_paths
 
@@ -51,6 +55,8 @@ contract.
 
 ## Statistical metrics
 
+::: purgedcv.DSRDiagnostics
+
 ::: purgedcv.probabilistic_sharpe_ratio
 
 ::: purgedcv.deflated_sharpe_ratio
@@ -64,6 +70,10 @@ contract.
 ::: purgedcv.effective_n_trials
 
 ## Backtest overfitting
+
+::: purgedcv.PBOResult
+
+::: purgedcv.PerformanceMetric
 
 ::: purgedcv.probability_of_backtest_overfitting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,10 +92,10 @@ src/purgedcv/
 ├── _purge.py            purge
 ├── _embargo.py          apply_embargo
 ├── _intervals.py        half-open / closed interval merges
-├── _time.py             parse_horizon, validate_times, horizons_overlap
+├── _time.py             HorizonLike, parse_horizon, validate_times, horizons_overlap
 ├── _metrics.py          probabilistic_sharpe_ratio, deflated_sharpe_ratio,
 │                        min_track_record_length
-├── _typing.py           NDArrayAny, HorizonLike
+├── _typing.py           ArrayLike1D, NDArrayAny, TimesLike
 ├── diagnostics.py       public assertions and per-fold audit report
 ├── exceptions.py        TemporalCVError tree
 └── py.typed             PEP 561 marker — the package is fully typed

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -103,7 +103,7 @@ constructor pattern.
 
 ### Audit what each fold removed
 
-Before running a large model search, inspect the splitter itself with
+Inspect the splitter first. Before a large model search, call
 `audit_splitter`. It uses the same internal fold pipeline as `split()` and
 reports each filtering stage rather than trying to reconstruct it from the
 final indices.

--- a/src/purgedcv/__init__.py
+++ b/src/purgedcv/__init__.py
@@ -5,6 +5,7 @@ from purgedcv._base import BaseTemporalSplitter
 from purgedcv._cpcv import CombinatoriallySymmetricCV, CombinatorialPurgedCV
 from purgedcv._embargo import apply_embargo
 from purgedcv._metrics import (
+    DSRDiagnostics,
     deflated_sharpe_ratio,
     deflated_sharpe_ratio_full,
     effective_n_trials,
@@ -12,12 +13,12 @@ from purgedcv._metrics import (
     minimum_backtest_length,
     probabilistic_sharpe_ratio,
 )
-from purgedcv._path_metrics import default_backtest_metrics, path_metrics
+from purgedcv._path_metrics import PathMetricFn, default_backtest_metrics, path_metrics
 from purgedcv._paths import reconstruct_paths
-from purgedcv._pbo import probability_of_backtest_overfitting
+from purgedcv._pbo import PBOResult, PerformanceMetric, probability_of_backtest_overfitting
 from purgedcv._purge import purge
 from purgedcv._purged_kfold import PurgedGroupKFold, PurgedKFold
-from purgedcv._time import horizons_overlap, parse_horizon, validate_times
+from purgedcv._time import HorizonLike, horizons_overlap, parse_horizon, validate_times
 from purgedcv._typing import ArrayLike1D, TimesLike
 from purgedcv._walk_forward import WalkForwardSplit
 from purgedcv.diagnostics import audit_splitter
@@ -35,8 +36,13 @@ __all__ = [
     "BaseTemporalSplitter",
     "CombinatorialPurgedCV",
     "CombinatoriallySymmetricCV",
+    "DSRDiagnostics",
     "EmbargoViolationError",
     "GroupLeakageError",
+    "HorizonLike",
+    "PBOResult",
+    "PathMetricFn",
+    "PerformanceMetric",
     "PurgedGroupKFold",
     "PurgedKFold",
     "TemporalCVError",

--- a/src/purgedcv/_time.py
+++ b/src/purgedcv/_time.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from ._typing import NDArrayAny, SupportsToNumpy, TimesLike
 
+#: A purge or embargo duration accepted as text or a timedelta scalar.
 HorizonLike = str | pd.Timedelta | timedelta | np.timedelta64
 
 _AMBIGUOUS_OFFSETS = frozenset(

--- a/tests/e2e/test_e2e_public_types.py
+++ b/tests/e2e/test_e2e_public_types.py
@@ -1,0 +1,89 @@
+"""End-to-end tests for the public result types and callback aliases (A7)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from dataclasses import FrozenInstanceError, asdict
+
+import numpy as np
+import pytest
+
+from purgedcv import (
+    DSRDiagnostics,
+    PBOResult,
+    deflated_sharpe_ratio_full,
+    probability_of_backtest_overfitting,
+)
+
+
+@pytest.mark.e2e
+def test_user_story_public_result_types_support_typed_downstream_code() -> None:
+    """User Story: an application imports documented result classes from the
+    package root, validates returned objects, and converts their frozen
+    dataclass fields for a report without importing private modules.
+    """
+    rng = np.random.default_rng(17)
+    returns = rng.normal(0.001, 0.01, 96)
+    diag = deflated_sharpe_ratio_full(returns, n_trials=20, var_sharpe=0.005**2)
+
+    assert isinstance(diag, DSRDiagnostics)
+    assert asdict(diag)["n_obs"] == 96
+    with pytest.raises(FrozenInstanceError):
+        diag.n_obs = 97  # type: ignore[misc]
+
+    strategy_returns = rng.normal(0.0, 0.01, (8, 96))
+    result = probability_of_backtest_overfitting(strategy_returns, n_splits=8)
+    assert isinstance(result, PBOResult)
+    assert asdict(result)["n_combos"] == 70
+    with pytest.raises(FrozenInstanceError):
+        result.pbo = 0.0  # type: ignore[misc]
+
+
+@pytest.mark.e2e
+def test_subprocess_can_use_all_public_a7_types() -> None:
+    """A fresh user environment can import and use all five A7 exports."""
+    snippet = textwrap.dedent("""\
+        import numpy as np
+        from purgedcv import (
+            DSRDiagnostics,
+            HorizonLike,
+            PBOResult,
+            PathMetricFn,
+            PerformanceMetric,
+            deflated_sharpe_ratio_full,
+            parse_horizon,
+            path_metrics,
+            probability_of_backtest_overfitting,
+        )
+
+        horizon: HorizonLike = "2D"
+        assert parse_horizon(horizon).days == 2
+
+        path_metric: PathMetricFn = lambda path: {"mean": float(np.mean(path))}
+        table = path_metrics(np.array([[0.01, 0.02], [-0.01, 0.01]]), path_metric)
+        assert list(table.columns) == ["mean"]
+
+        performance_metric: PerformanceMetric = lambda values: float(np.mean(values))
+        rng = np.random.default_rng(4)
+        matrix = rng.normal(0.0, 0.01, (8, 96))
+        pbo = probability_of_backtest_overfitting(
+            matrix, n_splits=8, metric=performance_metric
+        )
+        assert isinstance(pbo, PBOResult)
+
+        diag = deflated_sharpe_ratio_full(
+            matrix[0], n_trials=8, var_sharpe=0.005**2
+        )
+        assert isinstance(diag, DSRDiagnostics)
+        print("OK")
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "OK"
+    assert result.stderr == ""

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -28,6 +28,7 @@ EXPECTED_TOP_LEVEL: frozenset[str] = frozenset(
         "BaseTemporalSplitter",
         "CombinatorialPurgedCV",
         "CombinatoriallySymmetricCV",
+        "DSRDiagnostics",
         "default_backtest_metrics",
         "deflated_sharpe_ratio",
         "deflated_sharpe_ratio_full",
@@ -35,10 +36,14 @@ EXPECTED_TOP_LEVEL: frozenset[str] = frozenset(
         "effective_n_trials",
         "EmbargoViolationError",
         "GroupLeakageError",
+        "HorizonLike",
         "horizons_overlap",
         "min_track_record_length",
         "minimum_backtest_length",
         "parse_horizon",
+        "PathMetricFn",
+        "PBOResult",
+        "PerformanceMetric",
         "path_metrics",
         "probabilistic_sharpe_ratio",
         "probability_of_backtest_overfitting",
@@ -78,6 +83,19 @@ class TestTopLevelAPI:
         """Every name in __all__ must resolve as an actual attribute."""
         for name in EXPECTED_TOP_LEVEL:
             assert hasattr(purgedcv, name), f"missing public attribute: {name}"
+
+    def test_result_types_and_callback_aliases_are_canonical(self) -> None:
+        """A7 exports point at the types used by the implementation."""
+        from purgedcv._metrics import DSRDiagnostics
+        from purgedcv._path_metrics import PathMetricFn
+        from purgedcv._pbo import PBOResult, PerformanceMetric
+        from purgedcv._time import HorizonLike
+
+        assert purgedcv.DSRDiagnostics is DSRDiagnostics
+        assert purgedcv.PBOResult is PBOResult
+        assert purgedcv.HorizonLike is HorizonLike
+        assert purgedcv.PathMetricFn is PathMetricFn
+        assert purgedcv.PerformanceMetric is PerformanceMetric
 
     def test_no_unexpected_public_names(self) -> None:
         """Catch accidental leakage of internal names at the package level."""


### PR DESCRIPTION
## Summary

Expose the concrete result types and extension callback aliases used by the public API, so downstream applications can stay fully typed without importing private modules.

## What changes

- Export `PBOResult` and `DSRDiagnostics` from the package root. These are the frozen dataclasses returned by `probability_of_backtest_overfitting` and `deflated_sharpe_ratio_full`.
- Export `HorizonLike`, `PathMetricFn`, and `PerformanceMetric` for typed wrappers, custom path metrics, and custom PBO selection metrics.
- Pin all five names in the maintained top-level API contract.
- Add an end-to-end subprocess test that imports only from `purgedcv`, passes custom typed callbacks, checks the real return types, and verifies that the result dataclasses remain frozen.
- Document the exports in the API reference, README, architecture guide, and changelog. The architecture update also corrects the old claim that `HorizonLike` lived in `_typing.py`; it is defined in `_time.py`.
- Fix the inherited `docs/quickstart.md` burstiness failure so the prose gate is FAIL-free again.

## Downstream typing check

The public aliases were also exercised from an external-consumer-style module under `mypy --strict`, using callbacks annotated with concrete `numpy.typing.NDArray[np.float64]` parameters and assigning them to `PathMetricFn` and `PerformanceMetric`.

Mypy resolves `PBOResult.pbo` as `float` and `DSRDiagnostics.n_obs` as `int`, with no private imports and no type errors. The concrete callback annotations are compatible because the library aliases accept `NDArray[Any]`.

## Compatibility

This is an additive public API change. Runtime behavior and result layouts are unchanged; the existing canonical classes and aliases are re-exported rather than duplicated.

## Checklist

- [x] `ruff check . && black --check src tests tools examples/_lcl_harness.py` is clean.
- [x] `mypy src tests` is clean.
- [x] `pytest -q` is green locally.
- [x] User-visible behavior has an end-to-end test under `tests/e2e/`.
- [x] `python tools/prose_gate.py` is FAIL-free.
- [x] `mkdocs build --strict` is clean; all five A7 exports render in the generated API page.
- [x] `CHANGELOG.md` has an entry under `Unreleased`.

## Notes for the reviewer

`PathMetricFn` and `PerformanceMetric` already had source documentation comments. This PR adds the missing comment for `HorizonLike` and exposes all three aliases alongside the two public result dataclasses.
